### PR TITLE
refactor(user): 사용하지 않는 repository error 제거

### DIFF
--- a/src/user/application/use-cases/update-user-name.use-case.spec.ts
+++ b/src/user/application/use-cases/update-user-name.use-case.spec.ts
@@ -8,7 +8,6 @@ import { User } from "../../domain/entities/user.entity";
 import {
   UserNotFoundError,
   InvalidUserNameError,
-  RepositoryError,
 } from "../../domain/exceptions/user.exceptions";
 
 describe("UpdateUserNameUseCase", () => {

--- a/src/user/domain/exceptions/user.exceptions.ts
+++ b/src/user/domain/exceptions/user.exceptions.ts
@@ -38,16 +38,3 @@ export class UserNotFoundError extends UserDomainError {
     super(`사용자를 찾을 수 없습니다: ${identifier}`);
   }
 }
-
-export class RepositoryError extends UserDomainError {
-  readonly code = "REPOSITORY_ERROR";
-
-  constructor(operation: string, cause?: Error) {
-    super(
-      `리포지토리 오류 (${operation}): ${cause?.message || "알 수 없는 오류"}`
-    );
-    if (cause) {
-      this.stack = cause.stack;
-    }
-  }
-}

--- a/src/user/infrastructure/http/filters/user-exception.filter.ts
+++ b/src/user/infrastructure/http/filters/user-exception.filter.ts
@@ -11,7 +11,6 @@ import {
   InvalidEmailFormatError,
   InvalidUserNameError,
   UserNotFoundError,
-  RepositoryError,
 } from "@/user/domain/exceptions/user.exceptions";
 
 @Catch(UserDomainError)
@@ -59,12 +58,6 @@ export class UserExceptionFilter implements ExceptionFilter {
         return {
           status: HttpStatus.NOT_FOUND,
           message: "사용자를 찾을 수 없습니다.",
-        };
-
-      case RepositoryError:
-        return {
-          status: HttpStatus.INTERNAL_SERVER_ERROR,
-          message: "데이터 처리 중 오류가 발생했습니다.",
         };
 
       default:


### PR DESCRIPTION
- domain 계층 내에서 repository 레이어에 RepositoryError을 던지라고 문법적으로 강제하는 것이 불가능합니다.
- 그래서 그냥 지우는게 낫다고 판단했습니다. 나중에 더 좋은 아이디어 떠오를듯함.