### PR TITLE
feat: order 복구 로직 구현을 위해 idempotency key 각 모듈에 적용

### DIFF
--- a/src/coupon/application/services/coupon.service.ts
+++ b/src/coupon/application/services/coupon.service.ts
@@ -8,6 +8,7 @@ import { CancelUserCouponUseCase } from "@/coupon/domain/use-cases/cancel-user-c
 import { Coupon } from "@/coupon/domain/entities/coupon.entity";
 import { UserCoupon } from "@/coupon/domain/entities/user-coupon.entity";
 import { GetCouponByIdUseCase } from "@/coupon/domain/use-cases/get-coupon-by-id.use-case";
+import { RecoverUserCouponUseCase } from "@/coupon/domain/use-cases/recover-user-coupon.use-case";
 
 @Injectable()
 export class CouponApplicationService {
@@ -18,7 +19,8 @@ export class CouponApplicationService {
     private readonly issueUserCouponUseCase: IssueUserCouponUseCase,
     private readonly useUserCouponUseCase: UserCouponUseCase,
     private readonly validateCouponUseCase: ValidateCouponUseCase,
-    private readonly cancelUserCouponUseCase: CancelUserCouponUseCase
+    private readonly cancelUserCouponUseCase: CancelUserCouponUseCase,
+    private readonly recoverUserCouponUseCase: RecoverUserCouponUseCase
   ) {}
 
   async getAllCoupons(): Promise<Coupon[]> {
@@ -45,15 +47,18 @@ export class CouponApplicationService {
     couponId,
     userId,
     couponCode,
+    idempotencyKey,
   }: {
     couponId: string;
     userId: string;
     couponCode: string;
+    idempotencyKey: string;
   }): Promise<UserCoupon> {
     const result = await this.issueUserCouponUseCase.execute({
       couponId,
       userId,
       couponCode,
+      idempotencyKey,
     });
 
     return result.userCoupon;
@@ -63,13 +68,15 @@ export class CouponApplicationService {
     couponId: string,
     userId: string,
     orderId: string,
-    orderPrice: number
+    orderPrice: number,
+    idempotencyKey: string
   ): Promise<UserCoupon> {
     const result = await this.useUserCouponUseCase.execute({
       couponId,
       userId,
       orderId,
       orderPrice,
+      idempotencyKey,
     });
 
     return result.userCoupon;
@@ -100,6 +107,18 @@ export class CouponApplicationService {
   async cancelUserCoupon(userCouponId: string): Promise<UserCoupon> {
     const result = await this.cancelUserCouponUseCase.execute({
       userCouponId,
+    });
+
+    return result.userCoupon;
+  }
+
+  async recoverUserCoupon(
+    userCouponId: string,
+    idempotencyKey: string
+  ): Promise<UserCoupon> {
+    const result = await this.recoverUserCouponUseCase.execute({
+      userCouponId,
+      idempotencyKey,
     });
 
     return result.userCoupon;

--- a/src/coupon/coupon.module.ts
+++ b/src/coupon/coupon.module.ts
@@ -15,6 +15,7 @@ import { CouponRepository } from "./infrastructure/persistence/coupon.repository
 import { CouponTypeOrmEntity } from "./infrastructure/persistence/orm/coupon.typeorm.entity";
 import { UserCouponTypeOrmEntity } from "./infrastructure/persistence/orm/user-coupon.typeorm.entity";
 import { TypeOrmModule } from "@nestjs/typeorm";
+import { RecoverUserCouponUseCase } from "./domain/use-cases/recover-user-coupon.use-case";
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { TypeOrmModule } from "@nestjs/typeorm";
     UserCouponUseCase,
     ValidateCouponUseCase,
     CancelUserCouponUseCase,
+    RecoverUserCouponUseCase,
     {
       provide: "UserCouponRepositoryInterface",
       useClass: UserCouponRepository,

--- a/src/coupon/domain/exceptions/user-coupon.exception.ts
+++ b/src/coupon/domain/exceptions/user-coupon.exception.ts
@@ -31,3 +31,13 @@ export class UserCouponNotFoundError extends CouponDomainError {
     super(`존재하지 않는 쿠폰입니다. ID: ${userCouponId}`);
   }
 }
+
+export class UserCouponRecoverIdempotencyKeyMismatchError extends CouponDomainError {
+  readonly code = "USER_COUPON_RECOVER_IDEMPOTENCY_KEY_MISMATCH";
+
+  constructor(userCouponId: string, idempotencyKey: string) {
+    super(
+      `쿠폰 복구를 위한 멱등성 키가 일치하지 않습니다. ID: ${userCouponId}, 키: ${idempotencyKey}`
+    );
+  }
+}

--- a/src/coupon/domain/use-cases/cancel-user-coupon.user-case.spec.ts
+++ b/src/coupon/domain/use-cases/cancel-user-coupon.user-case.spec.ts
@@ -73,6 +73,7 @@ describe("CancelUserCouponUseCase", () => {
         couponId: coupon.id,
         userId: uuidv4(),
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
       });
 
       userCouponRepository.findById.mockResolvedValue(userCoupon);
@@ -106,11 +107,12 @@ describe("CancelUserCouponUseCase", () => {
         couponId: coupon.id,
         userId: uuidv4(),
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
       });
 
       // NOTE: 다른 유스케이스 가져다가 써야할수도
       const { discountPrice } = coupon.use(50000);
-      userCoupon.use("order-1", discountPrice);
+      userCoupon.use("order-1", discountPrice, uuidv4());
 
       const initialUsedCount = coupon.usedCount;
 
@@ -145,6 +147,7 @@ describe("CancelUserCouponUseCase", () => {
         couponId: coupon.id,
         userId: uuidv4(),
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
       });
 
       userCouponRepository.findById.mockResolvedValue(userCoupon);
@@ -180,6 +183,7 @@ describe("CancelUserCouponUseCase", () => {
         couponId: uuidv4(),
         userId: uuidv4(),
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
       });
 
       userCouponRepository.findById.mockResolvedValue(userCoupon);

--- a/src/coupon/domain/use-cases/issue-user-coupon.use-case.spec.ts
+++ b/src/coupon/domain/use-cases/issue-user-coupon.use-case.spec.ts
@@ -71,6 +71,7 @@ describe("IssueUserCouponUseCase", () => {
         couponId: coupon.id,
         userId,
         couponCode: "TEST123",
+        idempotencyKey: uuidv4(),
       });
 
       expect(result.coupon).toBe(coupon);
@@ -102,6 +103,7 @@ describe("IssueUserCouponUseCase", () => {
         couponId: coupon.id,
         userId: uuidv4(),
         couponCode: "EXPIRE123",
+        idempotencyKey: uuidv4(),
       });
 
       expect(result.userCoupon.expiresAt).toEqual(endDate);
@@ -118,6 +120,7 @@ describe("IssueUserCouponUseCase", () => {
           couponId: nonExistentCouponId,
           userId: uuidv4(),
           couponCode: "TEST123",
+          idempotencyKey: uuidv4(),
         })
       ).rejects.toThrow(CouponNotFoundError);
     });
@@ -144,6 +147,7 @@ describe("IssueUserCouponUseCase", () => {
           couponId: coupon.id,
           userId: uuidv4(),
           couponCode: "WRONG123",
+          idempotencyKey: uuidv4(),
         })
       ).rejects.toThrow(InvalidCouponCodeError);
     });
@@ -173,6 +177,7 @@ describe("IssueUserCouponUseCase", () => {
           couponId: coupon.id,
           userId: uuidv4(),
           couponCode: "EXPIRED123",
+          idempotencyKey: uuidv4(),
         })
       ).rejects.toThrow(CouponExpiredError);
     });
@@ -202,6 +207,7 @@ describe("IssueUserCouponUseCase", () => {
           couponId: coupon.id,
           userId: uuidv4(),
           couponCode: "LIMITED123",
+          idempotencyKey: uuidv4(),
         })
       ).rejects.toThrow(CouponExhaustedError);
     });

--- a/src/coupon/domain/use-cases/issue-user-coupon.use-case.ts
+++ b/src/coupon/domain/use-cases/issue-user-coupon.use-case.ts
@@ -9,6 +9,7 @@ export interface IssueUserCouponCommand {
   couponId: string;
   userId: string;
   couponCode: string;
+  idempotencyKey: string;
 }
 
 export interface IssueUserCouponResult {
@@ -28,7 +29,7 @@ export class IssueUserCouponUseCase {
   async execute(
     command: IssueUserCouponCommand
   ): Promise<IssueUserCouponResult> {
-    const { couponId, userId, couponCode } = command;
+    const { couponId, userId, couponCode, idempotencyKey } = command;
 
     const coupon = await this.couponRepository.findById(couponId);
     if (!coupon) {
@@ -41,6 +42,7 @@ export class IssueUserCouponUseCase {
       couponId,
       userId,
       expiresAt: coupon.endDate,
+      issuedIdempotencyKey: idempotencyKey,
     });
 
     await Promise.all([

--- a/src/coupon/domain/use-cases/recover-user-coupon.use-case.spec.ts
+++ b/src/coupon/domain/use-cases/recover-user-coupon.use-case.spec.ts
@@ -1,0 +1,184 @@
+import { Test } from "@nestjs/testing";
+import { RecoverUserCouponUseCase } from "./recover-user-coupon.use-case";
+import {
+  UserCouponNotFoundError,
+  UserCouponRecoverIdempotencyKeyMismatchError,
+} from "@/coupon/domain/exceptions/user-coupon.exception";
+import {
+  UserCoupon,
+  UserCouponStatus,
+} from "@/coupon/domain/entities/user-coupon.entity";
+import { v4 as uuidv4 } from "uuid";
+
+describe("RecoverUserCouponUseCase", () => {
+  let useCase: RecoverUserCouponUseCase;
+  let userCouponRepository: any;
+
+  beforeEach(async () => {
+    userCouponRepository = {
+      findById: jest.fn(),
+      save: jest.fn(),
+    };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        RecoverUserCouponUseCase,
+        {
+          provide: "UserCouponRepositoryInterface",
+          useValue: userCouponRepository,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<RecoverUserCouponUseCase>(RecoverUserCouponUseCase);
+  });
+
+  describe("쿠폰 복구 성공 케이스", () => {
+    it("사용된 쿠폰이 정상적으로 복구되어야 한다", async () => {
+      const userCoupon = UserCoupon.create({
+        couponId: uuidv4(),
+        userId: uuidv4(),
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
+      });
+
+      const orderId = uuidv4();
+      const discountPrice = 10000;
+      const usedIdempotencyKey = uuidv4();
+
+      // 쿠폰을 사용된 상태로 만들기
+      userCoupon.use(orderId, discountPrice, usedIdempotencyKey);
+
+      userCouponRepository.findById.mockResolvedValue(userCoupon);
+
+      const result = await useCase.execute({
+        userCouponId: userCoupon.id,
+        idempotencyKey: usedIdempotencyKey,
+      });
+
+      expect(result.userCoupon.status).toBe(UserCouponStatus.ISSUED);
+      expect(result.userCoupon.orderId).toBeNull();
+      expect(result.userCoupon.discountPrice).toBeNull();
+      expect(result.userCoupon.usedAt).toBeNull();
+    });
+
+    it("사용되지 않은 쿠폰으로 복구 요청시 아무것도 하지 않고 성공해야 한다", async () => {
+      const userCoupon = UserCoupon.create({
+        couponId: uuidv4(),
+        userId: uuidv4(),
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
+      });
+
+      const originalStatus = userCoupon.status;
+
+      userCouponRepository.findById.mockResolvedValue(userCoupon);
+
+      const result = await useCase.execute({
+        userCouponId: userCoupon.id,
+        idempotencyKey: uuidv4(),
+      });
+
+      expect(result.userCoupon.status).toBe(originalStatus);
+      expect(result.userCoupon.orderId).toBeNull();
+      expect(result.userCoupon.discountPrice).toBeNull();
+      expect(result.userCoupon.usedAt).toBeNull();
+    });
+
+    it("취소된 쿠폰으로 복구 요청시 아무것도 하지 않고 성공해야 한다", async () => {
+      const userCoupon = UserCoupon.create({
+        couponId: uuidv4(),
+        userId: uuidv4(),
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
+      });
+
+      userCoupon.cancel();
+      const originalStatus = userCoupon.status;
+
+      userCouponRepository.findById.mockResolvedValue(userCoupon);
+
+      const result = await useCase.execute({
+        userCouponId: userCoupon.id,
+        idempotencyKey: uuidv4(),
+      });
+
+      expect(result.userCoupon.status).toBe(originalStatus);
+      expect(result.userCoupon.cancelledAt).toBeDefined();
+    });
+  });
+
+  describe("쿠폰 복구 실패 케이스", () => {
+    it("존재하지 않는 사용자 쿠폰 ID로 요청시 에러가 발생해야 한다", async () => {
+      const nonExistentUserCouponId = uuidv4();
+      userCouponRepository.findById.mockResolvedValue(null);
+
+      await expect(
+        useCase.execute({
+          userCouponId: nonExistentUserCouponId,
+          idempotencyKey: uuidv4(),
+        })
+      ).rejects.toThrow(UserCouponNotFoundError);
+    });
+
+    it("잘못된 idempotencyKey로 요청시 에러가 발생해야 한다", async () => {
+      const userCoupon = UserCoupon.create({
+        couponId: uuidv4(),
+        userId: uuidv4(),
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
+      });
+
+      const orderId = uuidv4();
+      const discountPrice = 10000;
+      const correctIdempotencyKey = uuidv4();
+      const wrongIdempotencyKey = uuidv4();
+
+      // 쿠폰을 사용된 상태로 만들기
+      userCoupon.use(orderId, discountPrice, correctIdempotencyKey);
+
+      userCouponRepository.findById.mockResolvedValue(userCoupon);
+
+      await expect(
+        useCase.execute({
+          userCouponId: userCoupon.id,
+          idempotencyKey: wrongIdempotencyKey, // 잘못된 키 사용
+        })
+      ).rejects.toThrow(UserCouponRecoverIdempotencyKeyMismatchError);
+    });
+
+    it("동일한 idempotencyKey로 여러 번 복구 요청시 정상적으로 처리되어야 한다", async () => {
+      const userCoupon = UserCoupon.create({
+        couponId: uuidv4(),
+        userId: uuidv4(),
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
+      });
+
+      const orderId = uuidv4();
+      const discountPrice = 10000;
+      const usedIdempotencyKey = uuidv4();
+
+      // 쿠폰을 사용된 상태로 만들기
+      userCoupon.use(orderId, discountPrice, usedIdempotencyKey);
+
+      userCouponRepository.findById.mockResolvedValue(userCoupon);
+
+      // 첫 번째 복구
+      const firstResult = await useCase.execute({
+        userCouponId: userCoupon.id,
+        idempotencyKey: usedIdempotencyKey,
+      });
+
+      expect(firstResult.userCoupon.status).toBe(UserCouponStatus.ISSUED);
+
+      // 두 번째 복구 (이미 복구된 상태)
+      const secondResult = await useCase.execute({
+        userCouponId: userCoupon.id,
+        idempotencyKey: usedIdempotencyKey,
+      });
+
+      expect(secondResult.userCoupon.status).toBe(UserCouponStatus.ISSUED);
+    });
+  });
+});

--- a/src/coupon/domain/use-cases/recover-user-coupon.use-case.ts
+++ b/src/coupon/domain/use-cases/recover-user-coupon.use-case.ts
@@ -1,0 +1,40 @@
+import { UserCoupon } from "@/coupon/domain/entities/user-coupon.entity";
+import { UserCouponNotFoundError } from "@/coupon/domain/exceptions/user-coupon.exception";
+import { UserCouponRepositoryInterface } from "@/coupon/domain/interfaces/user-coupon.repository.interface";
+import { Inject, Injectable } from "@nestjs/common";
+
+export interface RecoverUserCouponCommand {
+  userCouponId: string;
+  idempotencyKey: string;
+}
+
+export interface RecoverUserCouponResult {
+  userCoupon: UserCoupon;
+}
+
+@Injectable()
+export class RecoverUserCouponUseCase {
+  constructor(
+    @Inject("UserCouponRepositoryInterface")
+    private readonly userCouponRepository: UserCouponRepositoryInterface
+  ) {}
+
+  async execute(
+    command: RecoverUserCouponCommand
+  ): Promise<RecoverUserCouponResult> {
+    const { userCouponId, idempotencyKey } = command;
+
+    const userCoupon = await this.userCouponRepository.findById(userCouponId);
+    if (!userCoupon) {
+      throw new UserCouponNotFoundError(userCouponId);
+    }
+
+    userCoupon.recover(idempotencyKey);
+
+    await this.userCouponRepository.save(userCoupon);
+
+    return {
+      userCoupon,
+    };
+  }
+}

--- a/src/coupon/domain/use-cases/use-user-coupon.use-case.spec.ts
+++ b/src/coupon/domain/use-cases/use-user-coupon.use-case.spec.ts
@@ -70,6 +70,7 @@ describe("UserCouponUseCase", () => {
           couponId: coupon.id,
           userId: uuidv4(),
           expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+          issuedIdempotencyKey: uuidv4(),
         });
 
         couponRepository.findById.mockResolvedValue(coupon);
@@ -83,6 +84,7 @@ describe("UserCouponUseCase", () => {
           userId: userCoupon.userId,
           orderId,
           orderPrice: 60000,
+          idempotencyKey: uuidv4(),
         });
 
         expect(result.discountPrice).toBe(10000);
@@ -115,6 +117,7 @@ describe("UserCouponUseCase", () => {
           couponId: coupon.id,
           userId: uuidv4(),
           expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+          issuedIdempotencyKey: uuidv4(),
         });
 
         couponRepository.findById.mockResolvedValue(coupon);
@@ -127,6 +130,7 @@ describe("UserCouponUseCase", () => {
           userId: userCoupon.userId,
           orderId: uuidv4(),
           orderPrice: 100000, // 50% = 50000원이지만 최대 20000원으로 제한
+          idempotencyKey: uuidv4(),
         });
 
         expect(result.discountPrice).toBe(20000);
@@ -152,6 +156,7 @@ describe("UserCouponUseCase", () => {
           couponId: coupon.id,
           userId: uuidv4(),
           expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+          issuedIdempotencyKey: uuidv4(),
         });
 
         couponRepository.findById.mockResolvedValue(coupon);
@@ -164,6 +169,7 @@ describe("UserCouponUseCase", () => {
           userId: userCoupon.userId,
           orderId: uuidv4(),
           orderPrice: 100000,
+          idempotencyKey: uuidv4(),
         });
 
         expect(result.discountPrice).toBe(30000);
@@ -189,6 +195,7 @@ describe("UserCouponUseCase", () => {
           couponId: coupon.id,
           userId: uuidv4(),
           expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+          issuedIdempotencyKey: uuidv4(),
         });
 
         couponRepository.findById.mockResolvedValue(coupon);
@@ -201,6 +208,7 @@ describe("UserCouponUseCase", () => {
           userId: userCoupon.userId,
           orderId: uuidv4(),
           orderPrice: 1235, // 10% = 123.5원 → 123원 (소수점 버림)
+          idempotencyKey: uuidv4(),
         });
 
         expect(result.discountPrice).toBe(123); // 123.5가 아닌 123원
@@ -220,6 +228,7 @@ describe("UserCouponUseCase", () => {
           userId: uuidv4(),
           orderId: uuidv4(),
           orderPrice: 10000,
+          idempotencyKey: uuidv4(),
         })
       ).rejects.toThrow(CouponNotFoundError);
     });
@@ -243,6 +252,7 @@ describe("UserCouponUseCase", () => {
         couponId: coupon.id,
         userId: uuidv4(),
         expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000), // 하루 전 만료
+        issuedIdempotencyKey: uuidv4(),
       });
 
       couponRepository.findById.mockResolvedValue(coupon);
@@ -256,6 +266,7 @@ describe("UserCouponUseCase", () => {
           userId: expiredUserCoupon.userId,
           orderId: uuidv4(),
           orderPrice: 60000,
+          idempotencyKey: uuidv4(),
         })
       ).rejects.toThrow(UserCouponExpiredError);
     });
@@ -279,9 +290,10 @@ describe("UserCouponUseCase", () => {
         couponId: coupon.id,
         userId: uuidv4(),
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
       });
 
-      userCoupon.use("previous-order", 10000);
+      userCoupon.use("previous-order", 10000, uuidv4());
 
       couponRepository.findById.mockResolvedValue(coupon);
       userCouponRepository.findByCouponIdAndUserId.mockResolvedValue(
@@ -294,6 +306,7 @@ describe("UserCouponUseCase", () => {
           userId: userCoupon.userId,
           orderId: uuidv4(),
           orderPrice: 60000,
+          idempotencyKey: uuidv4(),
         })
       ).rejects.toThrow(UserCouponAlreadyUsedError);
     });
@@ -317,6 +330,7 @@ describe("UserCouponUseCase", () => {
         couponId: coupon.id,
         userId: uuidv4(),
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
       });
 
       userCoupon.cancel();
@@ -332,6 +346,7 @@ describe("UserCouponUseCase", () => {
           userId: userCoupon.userId,
           orderId: uuidv4(),
           orderPrice: 60000,
+          idempotencyKey: uuidv4(),
         })
       ).rejects.toThrow(UserCouponCancelledError);
     });

--- a/src/coupon/domain/use-cases/use-user-coupon.use-case.ts
+++ b/src/coupon/domain/use-cases/use-user-coupon.use-case.ts
@@ -10,6 +10,7 @@ export interface UseUserCouponCommand {
   userId: string;
   orderId: string;
   orderPrice: number;
+  idempotencyKey: string;
 }
 
 export interface UseUserCouponResult {
@@ -29,7 +30,7 @@ export class UserCouponUseCase {
   ) {}
 
   async execute(command: UseUserCouponCommand): Promise<UseUserCouponResult> {
-    const { couponId, userId, orderId, orderPrice } = command;
+    const { couponId, userId, orderId, orderPrice, idempotencyKey } = command;
 
     const coupon = await this.couponRepository.findById(couponId);
     if (!coupon) {
@@ -42,7 +43,7 @@ export class UserCouponUseCase {
     );
 
     const { discountPrice, discountedPrice } = coupon.use(orderPrice);
-    userCoupon.use(orderId, discountPrice);
+    userCoupon.use(orderId, discountPrice, idempotencyKey);
 
     await Promise.all([
       this.couponRepository.save(coupon),

--- a/src/coupon/domain/use-cases/validate-user-coupon.use-case.spec.ts
+++ b/src/coupon/domain/use-cases/validate-user-coupon.use-case.spec.ts
@@ -62,6 +62,7 @@ describe("ValidateCouponUseCase", () => {
         couponId: coupon.id,
         userId: uuidv4(),
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
       });
 
       couponRepository.findById.mockResolvedValue(coupon);
@@ -99,6 +100,7 @@ describe("ValidateCouponUseCase", () => {
         couponId: coupon.id,
         userId: uuidv4(),
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
       });
 
       couponRepository.findById.mockResolvedValue(coupon);
@@ -138,6 +140,7 @@ describe("ValidateCouponUseCase", () => {
         couponId: coupon.id,
         userId: uuidv4(),
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
       });
 
       couponRepository.findById.mockResolvedValue(coupon);
@@ -175,6 +178,7 @@ describe("ValidateCouponUseCase", () => {
         couponId: coupon.id,
         userId: uuidv4(),
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
       });
 
       couponRepository.findById.mockResolvedValue(coupon);
@@ -214,6 +218,7 @@ describe("ValidateCouponUseCase", () => {
         couponId: coupon.id,
         userId: uuidv4(),
         expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000), // 하루 전 만료
+        issuedIdempotencyKey: uuidv4(),
       });
 
       couponRepository.findById.mockResolvedValue(coupon);
@@ -251,9 +256,10 @@ describe("ValidateCouponUseCase", () => {
         couponId: coupon.id,
         userId: uuidv4(),
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        issuedIdempotencyKey: uuidv4(),
       });
 
-      usedUserCoupon.use("order-1", 10000); // 쿠폰 사용 처리
+      usedUserCoupon.use("order-1", 10000, uuidv4()); // 쿠폰 사용 처리
 
       couponRepository.findById.mockResolvedValue(coupon);
       userCouponRepository.findByCouponIdAndUserId.mockResolvedValue(

--- a/src/coupon/infrastructure/http/coupon.controller.ts
+++ b/src/coupon/infrastructure/http/coupon.controller.ts
@@ -27,6 +27,7 @@ import {
 } from "@/common/decorators/current-user.decorator";
 import { CouponApplicationService } from "@/coupon/application/services/coupon.service";
 import { CouponExceptionFilter } from "./filters/coupon-exception.filter";
+import { v4 as uuidv4 } from "uuid";
 
 @ApiTags("쿠폰")
 @Controller("coupons")
@@ -102,10 +103,12 @@ export class CouponController {
     @Param("couponId") couponId: string,
     @Body() claimDto: ClaimCouponDto
   ): Promise<ApiResponseDto<UserCouponResponseDto>> {
+    const idempotencyKey = claimDto.idempotencyKey || uuidv4();
     const result = await this.couponService.issueUserCoupon({
       couponId,
       userId: user.id,
       couponCode: claimDto.couponCode,
+      idempotencyKey,
     });
     return ApiResponseDto.success(
       UserCouponResponseDto.fromUserCoupon(result),

--- a/src/coupon/infrastructure/http/dto/coupon.dto.ts
+++ b/src/coupon/infrastructure/http/dto/coupon.dto.ts
@@ -125,6 +125,15 @@ export class ClaimCouponDto {
   })
   @IsString()
   couponCode: string;
+
+  @ApiProperty({
+    description: "중복 요청 방지 ID",
+    example: "1234567890",
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  idempotencyKey?: string;
 }
 
 export class DiscountCalculationDto {

--- a/src/coupon/infrastructure/persistence/orm/user-coupon.typeorm.entity.ts
+++ b/src/coupon/infrastructure/persistence/orm/user-coupon.typeorm.entity.ts
@@ -39,6 +39,12 @@ export class UserCouponTypeOrmEntity {
   })
   status: UserCouponStatus;
 
+  @Column({ type: "varchar", name: "issued_idempotency_key", nullable: true })
+  issuedIdempotencyKey: string | null;
+
+  @Column({ type: "varchar", name: "used_idempotency_key", nullable: true })
+  usedIdempotencyKey: string | null;
+
   @Column({ type: "timestamp", name: "expires_at" })
   @Index("idx_user_coupons_expires_at")
   expiresAt: Date;

--- a/src/coupon/infrastructure/persistence/user-coupon.repository.ts
+++ b/src/coupon/infrastructure/persistence/user-coupon.repository.ts
@@ -54,6 +54,8 @@ export class UserCouponRepository implements UserCouponRepositoryInterface {
     entity.orderId = props.orderId;
     entity.discountPrice = props.discountPrice;
     entity.status = props.status;
+    entity.issuedIdempotencyKey = props.issuedIdempotencyKey;
+    entity.usedIdempotencyKey = props.usedIdempotencyKey;
     entity.expiresAt = props.expiresAt;
     entity.usedAt = props.usedAt;
     entity.cancelledAt = props.cancelledAt;
@@ -70,6 +72,8 @@ export class UserCouponRepository implements UserCouponRepositoryInterface {
       orderId: entity.orderId,
       discountPrice: entity.discountPrice,
       status: entity.status as UserCouponStatus,
+      issuedIdempotencyKey: entity.issuedIdempotencyKey,
+      usedIdempotencyKey: entity.usedIdempotencyKey,
       expiresAt: entity.expiresAt,
       usedAt: entity.usedAt,
       cancelledAt: entity.cancelledAt,

--- a/src/order/application/order.service.ts
+++ b/src/order/application/order.service.ts
@@ -182,7 +182,11 @@ export class OrderApplicationService {
 
     // 잔고 사용
     const finalAmountToPay = order.finalPrice;
-    await this.walletApplicationService.usePoints(userId, finalAmountToPay);
+    await this.walletApplicationService.usePoints(
+      userId,
+      finalAmountToPay,
+      idempotencyKey
+    );
 
     // 재고 확정
     await Promise.all(
@@ -236,11 +240,11 @@ export class OrderApplicationService {
     }
 
     // 잔고 복구
-    // TODO: order recover 할 때 idempotencyKey 기준으로 처리해야함. wallet 쪽 모두 필드 추가해주어야함. + Payment 테이블 추가 해야할듯?
-    // await this.walletApplicationService.recoverPoints(
-    //   order.userId,
-    //   order.discountPrice
-    // );
+    await this.walletApplicationService.recoverPoints(
+      order.userId,
+      order.discountPrice,
+      idempotencyKey
+    );
 
     // 주문 상태 변경
     await this.changeOrderStatusUseCase.execute({

--- a/src/order/application/order.service.ts
+++ b/src/order/application/order.service.ts
@@ -135,6 +135,7 @@ export class OrderApplicationService {
           productId: item.productId,
           userId,
           quantity: item.quantity,
+          idempotencyKey,
         });
       stockReservationIds.push(stockReservation.id);
     }
@@ -188,6 +189,7 @@ export class OrderApplicationService {
       stockReservationIds.map((stockReservationId) =>
         this.productApplicationService.confirmStock({
           stockReservationId,
+          idempotencyKey,
         })
       )
     );
@@ -213,14 +215,14 @@ export class OrderApplicationService {
     order: Order;
     couponId: string | null;
     stockReservationIds: string[];
-    idempotencyKey: string;
+    idempotencyKey: string; // order idempotencyKey 기준으로 모두 처리
   }) {
     // 재고 예약 취소
-    // TODO: 재고 예약 idempotencyKey 기준으로 처리해야함. product 쪽 모두 필드 추가해주어야함.
     await Promise.all(
       stockReservationIds.map((stockReservationId) =>
         this.productApplicationService.releaseStock({
           stockReservationId,
+          idempotencyKey,
         })
       )
     );

--- a/src/order/domain/use-cases/change-order-status.use-case.spec.ts
+++ b/src/order/domain/use-cases/change-order-status.use-case.spec.ts
@@ -81,8 +81,8 @@ describe("ChangeOrderStatusUseCase", () => {
 
         orderRepository.findById.mockResolvedValue(mockOrder);
 
-        // 시간 차이를 보장하기 위해 1ms 대기
-        await new Promise((resolve) => setTimeout(resolve, 1));
+        jest.useFakeTimers();
+        jest.advanceTimersByTime(10);
 
         // when
         const result = await useCase.execute({
@@ -130,8 +130,8 @@ describe("ChangeOrderStatusUseCase", () => {
 
     orderRepository.findById.mockResolvedValue(mockOrder);
 
-    // 시간 차이를 보장하기 위해 1ms 대기
-    await new Promise((resolve) => setTimeout(resolve, 1));
+    jest.useFakeTimers();
+    jest.advanceTimersByTime(10);
 
     // when
     const result = await useCase.execute({

--- a/src/order/infrastructure/http/dto/order.dto.ts
+++ b/src/order/infrastructure/http/dto/order.dto.ts
@@ -66,7 +66,7 @@ export class CreateOrderDto {
   })
   @IsOptional()
   @IsString()
-  requestId?: string;
+  idempotencyKey?: string;
 }
 
 export class OrderItemResponseDto {
@@ -136,7 +136,7 @@ export class OrderResponseDto {
   usedCouponName?: string;
 
   @ApiProperty({ description: "중복 요청 방지 ID" })
-  requestId: string;
+  idempotencyKey: string;
 
   @ApiProperty({ description: "주문 생성일시" })
   createdAt: Date;
@@ -158,7 +158,7 @@ export class OrderResponseDto {
       status: props.status as OrderStatus,
       usedCouponId: props.appliedCouponId,
       usedCouponName: props.appliedCouponId, // For simplicity
-      requestId: props.idempotencyKey,
+      idempotencyKey: props.idempotencyKey,
       createdAt: props.createdAt,
       updatedAt: props.updatedAt,
     };

--- a/src/order/infrastructure/http/order.controller.ts
+++ b/src/order/infrastructure/http/order.controller.ts
@@ -59,7 +59,7 @@ export class OrderController {
     @CurrentUser() user: CurrentUserData,
     @Body() createOrderDto: CreateOrderDto
   ): Promise<ApiResponseDto<OrderResponseDto>> {
-    const idempotencyKey = createOrderDto.requestId || uuidv4();
+    const idempotencyKey = createOrderDto.idempotencyKey || uuidv4();
 
     const { order } = await this.orderApplicationService.placeOrder({
       userId: user.id,

--- a/src/product/domain/entities/stock-reservation.entity.ts
+++ b/src/product/domain/entities/stock-reservation.entity.ts
@@ -1,10 +1,15 @@
 import { v4 as uuidv4 } from "uuid";
+import {
+  StockReservationConfirmStockIdempotencyKeyMismatchError,
+  StockReservationReleaseIdempotencyKeyMismatchError,
+} from "../exceptions/product.exceptions";
 
 export interface StockReservationProps {
   id: string;
   productId: string;
   userId: string;
   quantity: number;
+  idempotencyKey: string;
   createdAt: Date;
   updatedAt: Date;
   expiresAt: Date;
@@ -32,12 +37,24 @@ export class StockReservation {
     });
   }
 
-  releaseStock(): void {
+  releaseStock(idempotencyKey: string): void {
+    if (this.props.idempotencyKey !== idempotencyKey) {
+      throw new StockReservationReleaseIdempotencyKeyMismatchError(
+        this.props.id,
+        idempotencyKey
+      );
+    }
     this.props.isActive = false;
     this.props.updatedAt = new Date();
   }
 
-  confirmStock(): void {
+  confirmStock(idempotencyKey: string): void {
+    if (this.props.idempotencyKey !== idempotencyKey) {
+      throw new StockReservationConfirmStockIdempotencyKeyMismatchError(
+        this.props.id,
+        idempotencyKey
+      );
+    }
     this.props.isActive = false;
     this.props.updatedAt = new Date();
   }
@@ -52,6 +69,7 @@ export class StockReservation {
       productId: this.props.productId,
       userId: this.props.userId,
       quantity: this.props.quantity,
+      idempotencyKey: this.props.idempotencyKey,
       createdAt: this.props.createdAt,
       updatedAt: this.props.updatedAt,
       expiresAt: this.props.expiresAt,
@@ -73,6 +91,10 @@ export class StockReservation {
 
   get quantity(): number {
     return this.props.quantity;
+  }
+
+  get idempotencyKey(): string {
+    return this.props.idempotencyKey;
   }
 
   get createdAt(): Date {

--- a/src/product/domain/exceptions/product.exceptions.ts
+++ b/src/product/domain/exceptions/product.exceptions.ts
@@ -68,3 +68,23 @@ export class StockReservationExpiredError extends ProductDomainError {
     super(`재고 예약이 만료되었습니다. ID: ${stockReservationId}`);
   }
 }
+
+export class StockReservationReleaseIdempotencyKeyMismatchError extends ProductDomainError {
+  readonly code = "STOCK_RESERVATION_RELEASE_IDEMPOTENCY_KEY_MISMATCH";
+
+  constructor(stockReservationId: string, idempotencyKey: string) {
+    super(
+      `재고 예약 취소를 위한 멱등성 키가 일치하지 않습니다. ID: ${stockReservationId}, 키: ${idempotencyKey}`
+    );
+  }
+}
+
+export class StockReservationConfirmStockIdempotencyKeyMismatchError extends ProductDomainError {
+  readonly code = "STOCK_RESERVATION_CONFIRM_STOCK_IDEMPOTENCY_KEY_MISMATCH";
+
+  constructor(stockReservationId: string, idempotencyKey: string) {
+    super(
+      `재고 예약 확정을 위한 멱등성 키가 일치하지 않습니다. ID: ${stockReservationId}, 키: ${idempotencyKey}`
+    );
+  }
+}

--- a/src/product/domain/use-cases/confirm-stock.use-case.ts
+++ b/src/product/domain/use-cases/confirm-stock.use-case.ts
@@ -11,6 +11,7 @@ import { StockReservation } from "../entities/stock-reservation.entity";
 
 export interface ConfirmStockCommand {
   stockReservationId: string;
+  idempotencyKey: string;
 }
 
 @Injectable()
@@ -26,7 +27,7 @@ export class ConfirmStockUseCase {
     stockReservation: StockReservation;
     product: Product;
   }> {
-    const { stockReservationId } = command;
+    const { stockReservationId, idempotencyKey } = command;
 
     const stockReservation =
       await this.stockReservationRepository.findById(stockReservationId);
@@ -47,7 +48,7 @@ export class ConfirmStockUseCase {
       stockReservation.productId
     );
 
-    stockReservation.confirmStock();
+    stockReservation.confirmStock(idempotencyKey);
 
     await this.stockReservationRepository.save(stockReservation);
     await this.productRepository.save(product);

--- a/src/product/domain/use-cases/release-stock.use-case.spec.ts
+++ b/src/product/domain/use-cases/release-stock.use-case.spec.ts
@@ -81,6 +81,7 @@ describe("ReleaseStockUseCase", () => {
           productId: mockProduct.id,
           userId: uuidv4(),
           quantity: reservationQuantity,
+          idempotencyKey: uuidv4(),
         });
 
         stockReservationRepository.findById.mockResolvedValue(
@@ -90,6 +91,7 @@ describe("ReleaseStockUseCase", () => {
 
         const result = await useCase.execute({
           stockReservationId: "reservation-1",
+          idempotencyKey: mockStockReservation.idempotencyKey,
         });
 
         expect(mockStockReservation.isActive).toBe(false);
@@ -106,7 +108,10 @@ describe("ReleaseStockUseCase", () => {
     stockReservationRepository.findById.mockResolvedValue(null);
 
     await expect(
-      useCase.execute({ stockReservationId: "non-existent" })
+      useCase.execute({
+        stockReservationId: "non-existent",
+        idempotencyKey: "non-existent",
+      })
     ).rejects.toThrow(StockReservationNotFoundError);
   });
 
@@ -120,7 +125,10 @@ describe("ReleaseStockUseCase", () => {
     stockReservationRepository.findById.mockResolvedValue(inactiveReservation);
 
     await expect(
-      useCase.execute({ stockReservationId: "inactive-reservation" })
+      useCase.execute({
+        stockReservationId: "inactive-reservation",
+        idempotencyKey: "inactive-reservation",
+      })
     ).rejects.toThrow(StockReservationNotActiveError);
   });
 });

--- a/src/product/domain/use-cases/release-stock.use-case.ts
+++ b/src/product/domain/use-cases/release-stock.use-case.ts
@@ -10,6 +10,7 @@ import { StockReservation } from "@/product/domain/entities/stock-reservation.en
 
 export interface ReleaseStockCommand {
   stockReservationId: string;
+  idempotencyKey: string;
 }
 
 @Injectable()
@@ -25,7 +26,7 @@ export class ReleaseStockUseCase {
     stockReservation: StockReservation;
     product: Product;
   }> {
-    const { stockReservationId } = command;
+    const { stockReservationId, idempotencyKey } = command;
 
     const stockReservation =
       await this.stockReservationRepository.findById(stockReservationId);
@@ -42,7 +43,7 @@ export class ReleaseStockUseCase {
       stockReservation.productId
     );
 
-    stockReservation.releaseStock();
+    stockReservation.releaseStock(idempotencyKey);
     product.releaseStock(stockReservation.quantity);
 
     await this.stockReservationRepository.save(stockReservation);

--- a/src/product/domain/use-cases/reserve-stock.use-case.spec.ts
+++ b/src/product/domain/use-cases/reserve-stock.use-case.spec.ts
@@ -81,6 +81,7 @@ describe("ReserveStockUseCase", () => {
         productRepository.findById.mockResolvedValue(mockProduct);
 
         const result = await useCase.execute({
+          idempotencyKey: uuidv4(),
           productId: mockProduct.id,
           userId,
           quantity: reservationQuantity,
@@ -105,6 +106,7 @@ describe("ReserveStockUseCase", () => {
     async ({ quantity }) => {
       await expect(
         useCase.execute({
+          idempotencyKey: uuidv4(),
           productId: "product-1",
           userId: uuidv4(),
           quantity,
@@ -118,6 +120,7 @@ describe("ReserveStockUseCase", () => {
 
     await expect(
       useCase.execute({
+        idempotencyKey: uuidv4(),
         productId: "non-existent",
         userId: uuidv4(),
         quantity: 1,
@@ -139,6 +142,7 @@ describe("ReserveStockUseCase", () => {
 
     await expect(
       useCase.execute({
+        idempotencyKey: uuidv4(),
         productId: mockProduct.id,
         userId: uuidv4(),
         quantity: 1,
@@ -160,6 +164,7 @@ describe("ReserveStockUseCase", () => {
 
     await expect(
       useCase.execute({
+        idempotencyKey: uuidv4(),
         productId: mockProduct.id,
         userId: uuidv4(),
         quantity: 2,

--- a/src/product/domain/use-cases/reserve-stock.use-case.ts
+++ b/src/product/domain/use-cases/reserve-stock.use-case.ts
@@ -14,6 +14,7 @@ export interface ReserveStockCommand {
   productId: string;
   userId: string;
   quantity: number;
+  idempotencyKey: string;
 }
 
 @Injectable()
@@ -29,7 +30,7 @@ export class ReserveStockUseCase {
     stockReservation: StockReservation;
     product: Product;
   }> {
-    const { productId, userId, quantity } = command;
+    const { productId, userId, quantity, idempotencyKey } = command;
 
     if (quantity <= 0) {
       throw new InvalidQuantityError(quantity);
@@ -55,6 +56,7 @@ export class ReserveStockUseCase {
       productId,
       userId,
       quantity,
+      idempotencyKey,
     });
 
     // TODO: service 계층에서 transaction 처리 필요.

--- a/src/product/infrastructure/persistence/orm/stock-reservations.typeorm.entity.ts
+++ b/src/product/infrastructure/persistence/orm/stock-reservations.typeorm.entity.ts
@@ -24,6 +24,9 @@ export class StockReservationTypeOrmEntity {
   @Column({ type: "boolean", name: "is_active", default: true })
   isActive: boolean;
 
+  @Column({ type: "varchar", length: 255 })
+  idempotencyKey: string;
+
   @Column({ type: "timestamp", name: "expires_at" })
   expiresAt: Date;
 

--- a/src/wallet/application/wallet.service.ts
+++ b/src/wallet/application/wallet.service.ts
@@ -37,23 +37,27 @@ export class WalletApplicationService {
 
   async chargePoints(
     userId: string,
-    amount: number
+    amount: number,
+    idempotencyKey: string
   ): Promise<ChargePointsUseCaseResult> {
     // TODO: 외부 결제 api 검증 호출
     const result = await this.chargePointsUseCase.execute({
       userId,
       amount,
+      idempotencyKey,
     }); // TODO: 트랜잭션으로 묶어서 동시에 outbox payment 테이블에 등록 => 외부/다른곳에서 알아서 비동기로 결제 호출
     return result;
   }
 
   async usePoints(
     userId: string,
-    amount: number
+    amount: number,
+    idempotencyKey: string
   ): Promise<UsePointsUseCaseResult> {
     const result = await this.usePointsUseCase.execute({
       userId,
       amount,
+      idempotencyKey,
     });
 
     return result;
@@ -61,11 +65,13 @@ export class WalletApplicationService {
 
   async recoverPoints(
     userId: string,
-    amount: number
+    amount: number,
+    idempotencyKey: string
   ): Promise<RecoverPointsUseCaseResult> {
     const result = await this.recoverPointsUseCase.execute({
       userId,
       amount,
+      idempotencyKey,
     });
 
     return result;

--- a/src/wallet/domain/entities/point-transaction.entity.ts
+++ b/src/wallet/domain/entities/point-transaction.entity.ts
@@ -5,6 +5,7 @@ export interface PointTransactionProps {
   userId: string;
   amount: number;
   type: "CHARGE" | "USE" | "RECOVER";
+  idempotencyKey: string;
   createdAt: Date;
 }
 
@@ -29,5 +30,29 @@ export class PointTransaction {
     return {
       ...this.props,
     };
+  }
+
+  get id(): string {
+    return this.props.id;
+  }
+
+  get userId(): string {
+    return this.props.userId;
+  }
+
+  get amount(): number {
+    return this.props.amount;
+  }
+
+  get type(): "CHARGE" | "USE" | "RECOVER" {
+    return this.props.type;
+  }
+
+  get idempotencyKey(): string {
+    return this.props.idempotencyKey;
+  }
+
+  get createdAt(): Date {
+    return this.props.createdAt;
   }
 }

--- a/src/wallet/domain/entities/user-balance.entity.ts
+++ b/src/wallet/domain/entities/user-balance.entity.ts
@@ -73,4 +73,20 @@ export class UserBalance {
   get balance(): number {
     return this.props.balance;
   }
+
+  get id(): string {
+    return this.props.id;
+  }
+
+  get userId(): string {
+    return this.props.userId;
+  }
+
+  get createdAt(): Date {
+    return this.props.createdAt;
+  }
+
+  get updatedAt(): Date {
+    return this.props.updatedAt;
+  }
 }

--- a/src/wallet/domain/exceptions/point.exceptions.ts
+++ b/src/wallet/domain/exceptions/point.exceptions.ts
@@ -44,3 +44,19 @@ export class InvalidUseAmountError extends PointDomainError {
     );
   }
 }
+
+export class PointTransactionNotFoundError extends PointDomainError {
+  readonly code = "POINT_TRANSACTION_NOT_FOUND";
+
+  constructor(idempotencyKey: string) {
+    super(`사용 금액 트랜잭션을 찾을 수 없습니다. 키: ${idempotencyKey}`);
+  }
+}
+
+export class PointTransactionAlreadyRecoveredError extends PointDomainError {
+  readonly code = "POINT_TRANSACTION_ALREADY_RECOVERED";
+
+  constructor(idempotencyKey: string) {
+    super(`이미 복구된 트랜잭션입니다. 키: ${idempotencyKey}`);
+  }
+}

--- a/src/wallet/domain/interfaces/point-transaction.repository.ts
+++ b/src/wallet/domain/interfaces/point-transaction.repository.ts
@@ -2,5 +2,9 @@ import { PointTransaction } from "../entities/point-transaction.entity";
 
 export interface PointTransactionRepositoryInterface {
   findByUserId(userId: string): Promise<PointTransaction[]>;
+  findByOrderIdempotencyKey(
+    userId: string,
+    idempotencyKey: string
+  ): Promise<PointTransaction[]>;
   save(pointTransaction: PointTransaction): Promise<PointTransaction>;
 }

--- a/src/wallet/domain/use-cases/charge-points.use-case.spec.ts
+++ b/src/wallet/domain/use-cases/charge-points.use-case.spec.ts
@@ -6,6 +6,7 @@ import {
 } from "../exceptions/point.exceptions";
 import { UserBalanceRepositoryInterface } from "../interfaces/user-balance.repository";
 import { PointTransactionRepositoryInterface } from "../interfaces/point-transaction.repository";
+import { v4 as uuidv4 } from "uuid";
 
 describe("ChargePointsUseCase", () => {
   let useCase: ChargePointsUseCase;
@@ -22,6 +23,7 @@ describe("ChargePointsUseCase", () => {
 
     pointTransactionRepository = {
       findByUserId: jest.fn(),
+      findByOrderIdempotencyKey: jest.fn(),
       save: jest.fn(),
     };
 
@@ -58,6 +60,7 @@ describe("ChargePointsUseCase", () => {
         const result = await useCase.execute({
           userId: mockUserId,
           amount: chargeAmount,
+          idempotencyKey: uuidv4(),
         });
 
         // then
@@ -80,6 +83,7 @@ describe("ChargePointsUseCase", () => {
       useCase.execute({
         userId: mockUserId,
         amount: 10000,
+        idempotencyKey: uuidv4(),
       })
     ).rejects.toThrow(UserBalanceNotFoundError);
   });
@@ -110,6 +114,7 @@ describe("ChargePointsUseCase", () => {
           useCase.execute({
             userId: mockUserId,
             amount: chargeAmount,
+            idempotencyKey: uuidv4(),
           })
         ).rejects.toThrow(InvalidChargeAmountError);
       });

--- a/src/wallet/domain/use-cases/charge-points.use-case.ts
+++ b/src/wallet/domain/use-cases/charge-points.use-case.ts
@@ -8,6 +8,7 @@ import { UserBalanceRepositoryInterface } from "../interfaces/user-balance.repos
 export interface ChargePointsUseCaseCommand {
   userId: string;
   amount: number;
+  idempotencyKey: string;
 }
 
 export interface ChargePointsUseCaseResult {
@@ -27,7 +28,7 @@ export class ChargePointsUseCase {
   async execute(
     command: ChargePointsUseCaseCommand
   ): Promise<ChargePointsUseCaseResult> {
-    const { userId, amount } = command;
+    const { userId, amount, idempotencyKey } = command;
 
     const userBalance = await this.userBalanceRepository.findByUserId(userId);
 
@@ -40,6 +41,7 @@ export class ChargePointsUseCase {
       userId,
       amount,
       type: "CHARGE",
+      idempotencyKey,
     });
 
     await Promise.all([

--- a/src/wallet/domain/use-cases/use-points.use-case.spec.ts
+++ b/src/wallet/domain/use-cases/use-points.use-case.spec.ts
@@ -7,6 +7,7 @@ import {
 } from "../exceptions/point.exceptions";
 import { UserBalanceRepositoryInterface } from "../interfaces/user-balance.repository";
 import { PointTransactionRepositoryInterface } from "../interfaces/point-transaction.repository";
+import { v4 as uuidv4 } from "uuid";
 
 describe("UsePointsUseCase", () => {
   let useCase: UsePointsUseCase;
@@ -23,6 +24,7 @@ describe("UsePointsUseCase", () => {
 
     pointTransactionRepository = {
       findByUserId: jest.fn(),
+      findByOrderIdempotencyKey: jest.fn(),
       save: jest.fn(),
     };
 
@@ -58,6 +60,7 @@ describe("UsePointsUseCase", () => {
         const result = await useCase.execute({
           userId: mockUserId,
           amount: useAmount,
+          idempotencyKey: uuidv4(),
         });
 
         // then
@@ -94,6 +97,7 @@ describe("UsePointsUseCase", () => {
           useCase.execute({
             userId: mockUserId,
             amount: useAmount,
+            idempotencyKey: uuidv4(),
           })
         ).rejects.toThrow(InsufficientPointBalanceError);
       });
@@ -109,6 +113,7 @@ describe("UsePointsUseCase", () => {
       useCase.execute({
         userId: mockUserId,
         amount: 10000,
+        idempotencyKey: uuidv4(),
       })
     ).rejects.toThrow(UserBalanceNotFoundError);
   });

--- a/src/wallet/domain/use-cases/use-points.use-case.ts
+++ b/src/wallet/domain/use-cases/use-points.use-case.ts
@@ -11,6 +11,7 @@ import { UserBalanceRepositoryInterface } from "../interfaces/user-balance.repos
 export interface UsePointsUseCaseCommand {
   userId: string;
   amount: number;
+  idempotencyKey: string;
 }
 
 export interface UsePointsUseCaseResult {
@@ -30,7 +31,7 @@ export class UsePointsUseCase {
   async execute(
     command: UsePointsUseCaseCommand
   ): Promise<UsePointsUseCaseResult> {
-    const { userId, amount } = command;
+    const { userId, amount, idempotencyKey } = command;
 
     const userBalance = await this.userBalanceRepository.findByUserId(userId);
 
@@ -51,6 +52,7 @@ export class UsePointsUseCase {
       userId,
       amount,
       type: "USE",
+      idempotencyKey,
     });
 
     await Promise.all([

--- a/src/wallet/infrastructure/http/dto/wallet.dto.ts
+++ b/src/wallet/infrastructure/http/dto/wallet.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNumber, Min, Max, IsOptional, IsEnum } from "class-validator";
+import {
+  IsNumber,
+  Min,
+  Max,
+  IsOptional,
+  IsEnum,
+  IsString,
+} from "class-validator";
 import { Type } from "class-transformer";
 import { UserBalance } from "@/wallet/domain/entities/user-balance.entity";
 import { PointTransaction } from "@/wallet/domain/entities/point-transaction.entity";
@@ -16,6 +23,15 @@ export class ChargeBalanceDto {
   @Min(1000, { message: "최소 충전 금액은 1,000원입니다" })
   @Max(100000, { message: "1회 최대 충전 금액은 100,000원입니다" })
   amount: number;
+
+  @ApiProperty({
+    description: "거래 고유 키",
+    example: "123e4567-e89b-12d3-a456-426614174000",
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  idempotencyKey?: string;
 }
 
 export class BalanceResponseDto {

--- a/src/wallet/infrastructure/http/wallet.controller.ts
+++ b/src/wallet/infrastructure/http/wallet.controller.ts
@@ -26,6 +26,7 @@ import {
   CurrentUserData,
 } from "../../../common/decorators/current-user.decorator";
 import { WalletExceptionFilter } from "./filters/wallet-exception.filter";
+import { v4 as uuidv4 } from "uuid";
 
 @ApiTags("포인트/잔액")
 @Controller("users/me/points")
@@ -71,7 +72,8 @@ export class WalletController {
   ): Promise<ApiResponseDto<ChargeResponseDto>> {
     const result = await this.walletApplicationService.chargePoints(
       user.id,
-      chargeDto.amount
+      chargeDto.amount,
+      chargeDto.idempotencyKey ?? uuidv4()
     );
     return ApiResponseDto.success(
       ChargeResponseDto.fromPointTransaction(

--- a/src/wallet/infrastructure/persistence/orm/point-transaction.typeorm.entity.ts
+++ b/src/wallet/infrastructure/persistence/orm/point-transaction.typeorm.entity.ts
@@ -28,6 +28,9 @@ export class PointTransactionTypeOrmEntity {
   @Column({ type: "enum", name: "type", enum: PointTransactionType })
   type: PointTransactionType;
 
+  @Column({ type: "varchar", name: "idempotency_key" })
+  idempotencyKey: string;
+
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;
 

--- a/src/wallet/infrastructure/persistence/point-transaction.repository.ts
+++ b/src/wallet/infrastructure/persistence/point-transaction.repository.ts
@@ -24,6 +24,16 @@ export class PointTransactionRepository
     return entities.map((entity) => this.toDomain(entity));
   }
 
+  async findByOrderIdempotencyKey(
+    userId: string,
+    idempotencyKey: string
+  ): Promise<PointTransaction[]> {
+    const entities = await this.pointTransactionRepository.find({
+      where: { userId, idempotencyKey },
+    });
+    return entities.map((entity) => this.toDomain(entity));
+  }
+
   async save(pointTransaction: PointTransaction): Promise<PointTransaction> {
     const entity = this.fromDomain(pointTransaction);
     const savedEntity = await this.pointTransactionRepository.save(entity);
@@ -36,6 +46,7 @@ export class PointTransactionRepository
       userId: entity.userId,
       amount: entity.amount,
       type: entity.type as PointTransactionType,
+      idempotencyKey: entity.idempotencyKey,
       createdAt: entity.createdAt,
     });
   }
@@ -47,6 +58,7 @@ export class PointTransactionRepository
     entity.userId = props.userId;
     entity.amount = props.amount;
     entity.type = props.type as PointTransactionType;
+    entity.idempotencyKey = props.idempotencyKey;
     entity.createdAt = props.createdAt;
     return entity;
   }

--- a/test/e2e/order.e2e-spec.ts
+++ b/test/e2e/order.e2e-spec.ts
@@ -82,7 +82,7 @@ describe("Order API E2E (with TestContainers)", () => {
               quantity: 2,
             },
           ],
-          requestId: "test-order-001",
+          idempotencyKey: "test-order-001",
         })
         .expect(201);
 
@@ -93,7 +93,7 @@ describe("Order API E2E (with TestContainers)", () => {
         totalAmount: 20000, // 10000 * 2
         finalAmount: 20000,
         status: "SUCCESS",
-        requestId: "test-order-001",
+        idempotencyKey: "test-order-001",
       });
       expect(response.body.data.items).toHaveLength(1);
       expect(response.body.data.items[0]).toMatchObject({
@@ -169,7 +169,7 @@ describe("Order API E2E (with TestContainers)", () => {
         totalAmount: testOrder.totalPrice,
         finalAmount: testOrder.finalPrice,
         status: testOrder.status,
-        requestId: testOrder.idempotencyKey,
+        idempotencyKey: testOrder.idempotencyKey,
       });
       expect(response.body.message).toBe("주문 정보를 조회했습니다");
     });


### PR DESCRIPTION
### 💬 배경

- order 복구 로직 구현에 idempotency key가 각 모듈에 적용되지 않으면 복구하기가 어려워서 order의 idempotency key를 곳곳의 모듈들에서 같이 사용한 뒤에 롤백에 똑같이 사용하도록 구현했습니다.

### 📚 핵심 커밋 로그

- 쿠폰 idempotency key 적용하여 복구 가능하도록 구현: [9ab3458](https://github.com/seho0808/hh-9-be-2/pull/14/commits/9ab3458650b4dad502e3a3069f9dc4d2d02a9f9e) [544aa47](https://github.com/seho0808/hh-9-be-2/pull/14/commits/544aa47694e7e7098ccd7b08293c94a80dae9193) [96d19e7](https://github.com/seho0808/hh-9-be-2/pull/14/commits/96d19e7b4f6493f1af6171bfb20ce6c3705133e9)
- 재고 idempotency key 적용하여 복구 가능하도록 구현: [99e4126](https://github.com/seho0808/hh-9-be-2/pull/14/commits/99e4126ef28c8e6416c0d69aa4722c76ac7fb339) [02539c5](https://github.com/seho0808/hh-9-be-2/pull/14/commits/02539c53b43a2fd7e199b13cbd5801f839f8e691)
- 결제 idempotency key 적용하여 복구 가능하도록 구현: [e87c86c](https://github.com/seho0808/hh-9-be-2/pull/14/commits/e87c86cae7806b6c548de674e3a33ed35c7e9793) [340176b](https://github.com/seho0808/hh-9-be-2/pull/14/commits/340176b3785f5c1e64e2f10836667b473a58ba30) [ce838f2](https://github.com/seho0808/hh-9-be-2/pull/14/commits/ce838f2709bbe61b4613cc630c74239508e34568)

### 🤔 고민 포인트
- 사실 이거 자세하게 리서치 안하고 시간 이슈로 떠오르는 대로 구현한 부분이라 조금 불안함... idempotency key가 살짝 난잡하게 사용되고 있는 느낌? 
- order itempotency key라고 명명해주고 idempotency key 사용처에 따라 조금 다르게 분리하는게 조금 나을 수도 있을 것 같다.
- 하지만 지금도 사용은 가능해보임.