### PR TITLE
feat: application 계층 트랜잭션 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/schedule": "^6.0.0",
     "@nestjs/swagger": "^7.3.0",
     "@nestjs/typeorm": "^10.0.2",
     "bcrypt": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^10.0.0
         version: 10.4.19(@nestjs/common@10.4.19(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.19)
+      '@nestjs/schedule':
+        specifier: ^6.0.0
+        version: 6.0.0(@nestjs/common@10.4.19(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.19)
       '@nestjs/swagger':
         specifier: ^7.3.0
         version: 7.4.2(@nestjs/common@10.4.19(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.19)(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)
@@ -555,6 +558,12 @@ packages:
       '@nestjs/common': ^10.0.0
       '@nestjs/core': ^10.0.0
 
+  '@nestjs/schedule@6.0.0':
+    resolution: {integrity: sha512-aQySMw6tw2nhitELXd3EiRacQRgzUKD9mFcUZVOJ7jPLqIBvXOyvRWLsK9SdurGA+jjziAlMef7iB5ZEFFoQpw==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+
   '@nestjs/schematics@10.2.3':
     resolution: {integrity: sha512-4e8gxaCk7DhBxVUly2PjYL4xC2ifDFexCqq1/u4TtivLGXotVk0wHdYuPYe1tHTHuR1lsOkRbfOCpkdTnigLVg==}
     peerDependencies:
@@ -763,6 +772,9 @@ packages:
 
   '@types/jsonwebtoken@9.0.7':
     resolution: {integrity: sha512-ugo316mmTYBl2g81zDFnZ7cfxlut3o+/EQdaP7J8QN2kY6lJ22hmQYCK5EHcJHbrW+dkCGSCPgbG8JtYj6qSrg==}
+
+  '@types/luxon@3.6.2':
+    resolution: {integrity: sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==}
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
@@ -1405,6 +1417,10 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  cron@4.3.0:
+    resolution: {integrity: sha512-ciiYNLfSlF9MrDqnbMdRWFiA6oizSF7kA1osPP9lRzNu0Uu+AWog1UKy7SkckiDY2irrNjeO6qLyKnXC8oxmrw==}
+    engines: {node: '>=18.x'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2354,6 +2370,10 @@ packages:
   lru.min@1.1.2:
     resolution: {integrity: sha512-Nv9KddBcQSlQopmBHXSsZVY5xsdlZkdH/Iey0BlcBYggMd4two7cZnKOK9vmy3nY0O5RGH99z1PCeTpPqszUYg==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
+  luxon@3.6.1:
+    resolution: {integrity: sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.8:
     resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
@@ -4055,6 +4075,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nestjs/schedule@6.0.0(@nestjs/common@10.4.19(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.19)':
+    dependencies:
+      '@nestjs/common': 10.4.19(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.19(@nestjs/common@10.4.19(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cron: 4.3.0
+
   '@nestjs/schematics@10.2.3(chokidar@3.6.0)(typescript@5.7.2)':
     dependencies:
       '@angular-devkit/core': 17.3.11(chokidar@3.6.0)
@@ -4299,6 +4325,8 @@ snapshots:
   '@types/jsonwebtoken@9.0.7':
     dependencies:
       '@types/node': 20.19.7
+
+  '@types/luxon@3.6.2': {}
 
   '@types/methods@1.1.4': {}
 
@@ -5039,6 +5067,11 @@ snapshots:
       - ts-node
 
   create-require@1.1.1: {}
+
+  cron@4.3.0:
+    dependencies:
+      '@types/luxon': 3.6.2
+      luxon: 3.6.1
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6231,6 +6264,8 @@ snapshots:
   lru-cache@7.18.3: {}
 
   lru.min@1.1.2: {}
+
+  luxon@3.6.1: {}
 
   magic-string@0.30.8:
     dependencies:

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from "@nestjs/common";
+import { ScheduleModule } from "@nestjs/schedule";
 import { DatabaseModule } from "./database/database.module";
 import { AuthModule } from "./auth/auth.module";
 import { UserModule } from "./user/user.module";
@@ -9,6 +10,7 @@ import { OrderModule } from "./order/order.module";
 
 @Module({
   imports: [
+    ScheduleModule.forRoot(),
     // DatabaseModule,
     AuthModule,
     UserModule,

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -30,11 +30,11 @@ export class AuthService {
 
     const hashedPassword = this.hashPassword(password);
 
-    const user = await this.userApplicationService.createUser(
+    const user = await this.userApplicationService.createUser({
       email,
       hashedPassword,
-      name
-    );
+      name,
+    });
 
     return this.userToRegisterResponseDto(user);
   }

--- a/src/common/services/transaction.service.ts
+++ b/src/common/services/transaction.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from "@nestjs/common";
+import { DataSource, EntityManager } from "typeorm";
+
+export interface RepositoryWithTransaction {
+  setEntityManager(manager: EntityManager): void;
+  clearEntityManager(): void;
+}
+
+@Injectable()
+export class TransactionService {
+  constructor(private readonly dataSource: DataSource) {}
+
+  async executeInTransaction<T>(
+    repositories: RepositoryWithTransaction[],
+    operation: (manager?: EntityManager) => Promise<T>,
+    parentManager?: EntityManager
+  ): Promise<T> {
+    if (parentManager) {
+      repositories.forEach((repo) => repo.setEntityManager(parentManager));
+
+      try {
+        return await operation(parentManager);
+      } finally {
+        repositories.forEach((repo) => repo.clearEntityManager());
+      }
+    }
+
+    return await this.dataSource.transaction(async (manager) => {
+      repositories.forEach((repo) => repo.setEntityManager(manager));
+
+      try {
+        return await operation(manager);
+      } finally {
+        repositories.forEach((repo) => repo.clearEntityManager());
+      }
+    });
+  }
+}

--- a/src/coupon/coupon.module.ts
+++ b/src/coupon/coupon.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { CouponController } from "./infrastructure/http/coupon.controller";
 import { AuthModule } from "../auth/auth.module";
+import { TransactionService } from "../common/services/transaction.service";
 import { UserCouponController } from "./infrastructure/http/user-coupon.controller";
 import { CouponApplicationService } from "./application/services/coupon.service";
 import { GetAllCouponsUseCase } from "./domain/use-cases/get-all-coupons.use-case";
@@ -24,6 +25,7 @@ import { RecoverUserCouponUseCase } from "./domain/use-cases/recover-user-coupon
   ],
   controllers: [CouponController, UserCouponController],
   providers: [
+    TransactionService,
     CouponApplicationService,
     GetAllCouponsUseCase,
     GetAllUserCouponsUseCase,

--- a/src/coupon/infrastructure/persistence/coupon.repository.ts
+++ b/src/coupon/infrastructure/persistence/coupon.repository.ts
@@ -7,6 +7,7 @@ import {
   CouponDiscountType,
 } from "@/coupon/domain/entities/coupon.entity";
 import { CouponTypeOrmEntity } from "./orm/coupon.typeorm.entity";
+import { TransactionContext } from "@/common/services/transaction.service";
 
 @Injectable()
 export class CouponRepository implements CouponRepositoryInterface {
@@ -15,7 +16,9 @@ export class CouponRepository implements CouponRepositoryInterface {
   constructor(
     @InjectRepository(CouponTypeOrmEntity)
     private readonly couponRepository: Repository<CouponTypeOrmEntity>
-  ) {}
+  ) {
+    TransactionContext.registerRepository(this);
+  }
 
   setEntityManager(manager: EntityManager): void {
     this.entityManager = manager;

--- a/src/coupon/infrastructure/persistence/user-coupon.repository.ts
+++ b/src/coupon/infrastructure/persistence/user-coupon.repository.ts
@@ -7,6 +7,7 @@ import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository, EntityManager } from "typeorm";
 import { UserCouponTypeOrmEntity } from "./orm/user-coupon.typeorm.entity";
+import { TransactionContext } from "@/common/services/transaction.service";
 
 @Injectable()
 export class UserCouponRepository implements UserCouponRepositoryInterface {
@@ -15,7 +16,9 @@ export class UserCouponRepository implements UserCouponRepositoryInterface {
   constructor(
     @InjectRepository(UserCouponTypeOrmEntity)
     private readonly userCouponRepository: Repository<UserCouponTypeOrmEntity>
-  ) {}
+  ) {
+    TransactionContext.registerRepository(this);
+  }
 
   setEntityManager(manager: EntityManager): void {
     this.entityManager = manager;

--- a/src/order/application/order-recovery.service.ts
+++ b/src/order/application/order-recovery.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from "@nestjs/common";
+import { Cron, CronExpression } from "@nestjs/schedule";
+import { OrderApplicationService } from "./order.service";
+import { Order } from "../domain/entities/order.entitiy";
+import { ProductApplicationService } from "@/product/application/services/product.service";
+import { TransactionService } from "@/common/services/transaction.service";
+
+@Injectable()
+export class OrderRecoveryService {
+  constructor(
+    private readonly orderApplicationService: OrderApplicationService,
+    private readonly productApplicationService: ProductApplicationService,
+    private readonly transactionService: TransactionService
+  ) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async recoverStalePendingOrders(): Promise<void> {
+    const stalePendingOrders =
+      await this.orderApplicationService.findStalePendingOrders(10, 50);
+
+    if (stalePendingOrders.length === 0) return;
+
+    for (const order of stalePendingOrders) {
+      await this.recoverSingleOrder(order);
+    }
+  }
+
+  @Cron(CronExpression.EVERY_10_MINUTES)
+  async retryFailedOrders(): Promise<void> {
+    const failedOrders =
+      await this.orderApplicationService.findFailedOrders(20);
+
+    if (failedOrders.length === 0) return;
+
+    for (const order of failedOrders) {
+      await this.recoverSingleOrder(order);
+    }
+  }
+
+  private async recoverSingleOrder(order: Order): Promise<void> {
+    await this.transactionService.runWithTransaction(async (manager) => {
+      const stockReservationIds = await this.getStockReservationIds(order);
+
+      await this.orderApplicationService.recoverOrder({
+        order,
+        couponId: order.appliedCouponId,
+        stockReservationIds,
+        idempotencyKey: order.idempotencyKey,
+      });
+    });
+  }
+
+  private async getStockReservationIds(order: Order): Promise<string[]> {
+    const stockReservationIds =
+      await this.productApplicationService.getStockReservationIdsByIdempotencyKey(
+        order.idempotencyKey
+      );
+
+    return stockReservationIds;
+  }
+}

--- a/src/order/application/order.service.ts
+++ b/src/order/application/order.service.ts
@@ -212,6 +212,7 @@ export class OrderApplicationService {
 
         // 재고 확정
         await Promise.all(
+          // TODO: 한 번의 쿼리로 변경되도록 use-case 수정 필요함.
           stockReservationIds.map((stockReservationId) =>
             this.productApplicationService.confirmStock(
               {
@@ -250,6 +251,7 @@ export class OrderApplicationService {
   }) {
     await this.transactionService.runWithTransaction(async (manager) => {
       // 재고 예약 취소
+      // TODO: 한 번의 쿼리로 변경되도록 use-case 수정 필요함.
       await Promise.all(
         stockReservationIds.map((stockReservationId) =>
           this.productApplicationService.releaseStock(

--- a/src/order/domain/interfaces/order.repository.interface.ts
+++ b/src/order/domain/interfaces/order.repository.interface.ts
@@ -4,4 +4,9 @@ export interface OrderRepositoryInterface {
   save(order: Order): Promise<Order>;
   findById(id: string): Promise<Order | null>;
   findByUserId(userId: string): Promise<Order[]>;
+  findStalePendingOrders(
+    minutesThreshold: number,
+    limit: number
+  ): Promise<Order[]>;
+  findFailedOrders(limit: number): Promise<Order[]>;
 }

--- a/src/order/domain/use-cases/find-failed-orders.use-case.ts
+++ b/src/order/domain/use-cases/find-failed-orders.use-case.ts
@@ -1,0 +1,29 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { OrderRepositoryInterface } from "../interfaces/order.repository.interface";
+import { Order } from "../entities/order.entitiy";
+
+export interface FindFailedOrdersUseCaseCommand {
+  limit: number;
+}
+
+export interface FindFailedOrdersUseCaseResult {
+  orders: Order[];
+}
+
+@Injectable()
+export class FindFailedOrdersUseCase {
+  constructor(
+    @Inject("OrderRepositoryInterface")
+    private readonly orderRepository: OrderRepositoryInterface
+  ) {}
+
+  async execute(
+    command: FindFailedOrdersUseCaseCommand
+  ): Promise<FindFailedOrdersUseCaseResult> {
+    const { limit } = command;
+
+    const orders = await this.orderRepository.findFailedOrders(limit);
+
+    return { orders };
+  }
+}

--- a/src/order/domain/use-cases/find-stale-pending-orders.use-case.ts
+++ b/src/order/domain/use-cases/find-stale-pending-orders.use-case.ts
@@ -1,0 +1,33 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { OrderRepositoryInterface } from "../interfaces/order.repository.interface";
+import { Order } from "../entities/order.entitiy";
+
+export interface FindStalePendingOrdersUseCaseCommand {
+  minutesThreshold: number;
+  limit: number;
+}
+
+export interface FindStalePendingOrdersUseCaseResult {
+  orders: Order[];
+}
+
+@Injectable()
+export class FindStalePendingOrdersUseCase {
+  constructor(
+    @Inject("OrderRepositoryInterface")
+    private readonly orderRepository: OrderRepositoryInterface
+  ) {}
+
+  async execute(
+    command: FindStalePendingOrdersUseCaseCommand
+  ): Promise<FindStalePendingOrdersUseCaseResult> {
+    const { minutesThreshold, limit } = command;
+
+    const orders = await this.orderRepository.findStalePendingOrders(
+      minutesThreshold,
+      limit
+    );
+
+    return { orders };
+  }
+}

--- a/src/order/infrastructure/persistence/order-item.repository.ts
+++ b/src/order/infrastructure/persistence/order-item.repository.ts
@@ -1,20 +1,37 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import { Repository, EntityManager } from "typeorm";
 import { OrderItemRepositoryInterface } from "@/order/domain/interfaces/order-item.repository.interface";
 import { OrderItem } from "@/order/domain/entities/order-item.entity";
 import { OrderItemTypeOrmEntity } from "./orm/order-item.typeorm.entity";
 
 @Injectable()
 export class OrderItemRepository implements OrderItemRepositoryInterface {
+  private entityManager?: EntityManager;
+
   constructor(
     @InjectRepository(OrderItemTypeOrmEntity)
     private readonly orderItemRepository: Repository<OrderItemTypeOrmEntity>
   ) {}
 
+  setEntityManager(manager: EntityManager): void {
+    this.entityManager = manager;
+  }
+
+  clearEntityManager(): void {
+    this.entityManager = undefined;
+  }
+
+  private getRepository(): Repository<OrderItemTypeOrmEntity> {
+    return this.entityManager
+      ? this.entityManager.getRepository(OrderItemTypeOrmEntity)
+      : this.orderItemRepository;
+  }
+
   async save(orderItem: OrderItem): Promise<void> {
+    const repository = this.getRepository();
     const entity = this.fromDomain(orderItem);
-    await this.orderItemRepository.save(entity);
+    await repository.save(entity);
   }
 
   private fromDomain(orderItem: OrderItem): OrderItemTypeOrmEntity {

--- a/src/order/infrastructure/persistence/order-item.repository.ts
+++ b/src/order/infrastructure/persistence/order-item.repository.ts
@@ -4,6 +4,7 @@ import { Repository, EntityManager } from "typeorm";
 import { OrderItemRepositoryInterface } from "@/order/domain/interfaces/order-item.repository.interface";
 import { OrderItem } from "@/order/domain/entities/order-item.entity";
 import { OrderItemTypeOrmEntity } from "./orm/order-item.typeorm.entity";
+import { TransactionContext } from "@/common/services/transaction.service";
 
 @Injectable()
 export class OrderItemRepository implements OrderItemRepositoryInterface {
@@ -12,7 +13,9 @@ export class OrderItemRepository implements OrderItemRepositoryInterface {
   constructor(
     @InjectRepository(OrderItemTypeOrmEntity)
     private readonly orderItemRepository: Repository<OrderItemTypeOrmEntity>
-  ) {}
+  ) {
+    TransactionContext.registerRepository(this);
+  }
 
   setEntityManager(manager: EntityManager): void {
     this.entityManager = manager;

--- a/src/order/infrastructure/persistence/order.repository.ts
+++ b/src/order/infrastructure/persistence/order.repository.ts
@@ -5,6 +5,7 @@ import { OrderRepositoryInterface } from "@/order/domain/interfaces/order.reposi
 import { Order, OrderStatus } from "@/order/domain/entities/order.entitiy";
 import { OrderTypeOrmEntity } from "./orm/order.typeorm.entity";
 import { OrderItem } from "@/order/domain/entities/order-item.entity";
+import { TransactionContext } from "@/common/services/transaction.service";
 
 @Injectable()
 export class OrderRepository implements OrderRepositoryInterface {
@@ -13,7 +14,9 @@ export class OrderRepository implements OrderRepositoryInterface {
   constructor(
     @InjectRepository(OrderTypeOrmEntity)
     private readonly orderRepository: Repository<OrderTypeOrmEntity>
-  ) {}
+  ) {
+    TransactionContext.registerRepository(this);
+  }
 
   setEntityManager(manager: EntityManager): void {
     this.entityManager = manager;

--- a/src/order/order.module.ts
+++ b/src/order/order.module.ts
@@ -29,6 +29,7 @@ import { PointTransactionTypeOrmEntity } from "../wallet/infrastructure/persiste
 
 // Application
 import { OrderApplicationService } from "./application/order.service";
+import { OrderRecoveryService } from "./application/order-recovery.service";
 
 // Common services
 import { TransactionService } from "../common/services/transaction.service";
@@ -39,6 +40,8 @@ import { ApplyDiscountUseCase } from "./domain/use-cases/apply-discount.use-case
 import { ChangeOrderStatusUseCase } from "./domain/use-cases/change-order-status.use-case";
 import { GetOrderByIdUseCase } from "./domain/use-cases/get-order-by-id.use-case";
 import { GetOrderByUserIdUseCase } from "./domain/use-cases/get-order-by-user-id.use-case";
+import { FindStalePendingOrdersUseCase } from "./domain/use-cases/find-stale-pending-orders.use-case";
+import { FindFailedOrdersUseCase } from "./domain/use-cases/find-failed-orders.use-case";
 
 @Module({
   imports: [
@@ -61,11 +64,14 @@ import { GetOrderByUserIdUseCase } from "./domain/use-cases/get-order-by-user-id
   providers: [
     TransactionService,
     OrderApplicationService,
+    OrderRecoveryService,
     CreateOrderUseCase,
     ApplyDiscountUseCase,
     ChangeOrderStatusUseCase,
     GetOrderByIdUseCase,
     GetOrderByUserIdUseCase,
+    FindStalePendingOrdersUseCase,
+    FindFailedOrdersUseCase,
     {
       provide: "OrderRepositoryInterface",
       useClass: OrderRepository,

--- a/src/order/order.module.ts
+++ b/src/order/order.module.ts
@@ -14,9 +14,24 @@ import { OrderTypeOrmEntity } from "./infrastructure/persistence/orm/order.typeo
 import { OrderItemTypeOrmEntity } from "./infrastructure/persistence/orm/order-item.typeorm.entity";
 import { OrderRepository } from "./infrastructure/persistence/order.repository";
 import { OrderItemRepository } from "./infrastructure/persistence/order-item.repository";
+import { CouponRepository } from "../coupon/infrastructure/persistence/coupon.repository";
+import { UserCouponRepository } from "../coupon/infrastructure/persistence/user-coupon.repository";
+import { ProductRepository } from "../product/infrastructure/persistence/product.repository";
+import { StockReservationRepository } from "../product/infrastructure/persistence/stock-reservations.repository";
+import { UserBalanceRepository } from "../wallet/infrastructure/persistence/use-balance.repository";
+import { PointTransactionRepository } from "../wallet/infrastructure/persistence/point-transaction.repository";
+import { CouponTypeOrmEntity } from "../coupon/infrastructure/persistence/orm/coupon.typeorm.entity";
+import { UserCouponTypeOrmEntity } from "../coupon/infrastructure/persistence/orm/user-coupon.typeorm.entity";
+import { ProductTypeOrmEntity } from "../product/infrastructure/persistence/orm/product.typeorm.entity";
+import { StockReservationTypeOrmEntity } from "../product/infrastructure/persistence/orm/stock-reservations.typeorm.entity";
+import { UserBalanceTypeOrmEntity } from "../wallet/infrastructure/persistence/orm/user-balance.typeorm.entity";
+import { PointTransactionTypeOrmEntity } from "../wallet/infrastructure/persistence/orm/point-transaction.typeorm.entity";
 
 // Application
 import { OrderApplicationService } from "./application/order.service";
+
+// Common services
+import { TransactionService } from "../common/services/transaction.service";
 
 // Domain Use Cases
 import { CreateOrderUseCase } from "./domain/use-cases/create-order.use-case";
@@ -27,7 +42,16 @@ import { GetOrderByUserIdUseCase } from "./domain/use-cases/get-order-by-user-id
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([OrderTypeOrmEntity, OrderItemTypeOrmEntity]),
+    TypeOrmModule.forFeature([
+      OrderTypeOrmEntity,
+      OrderItemTypeOrmEntity,
+      CouponTypeOrmEntity,
+      UserCouponTypeOrmEntity,
+      ProductTypeOrmEntity,
+      StockReservationTypeOrmEntity,
+      UserBalanceTypeOrmEntity,
+      PointTransactionTypeOrmEntity,
+    ]),
     forwardRef(() => AuthModule),
     forwardRef(() => ProductModule),
     forwardRef(() => WalletModule),
@@ -35,6 +59,7 @@ import { GetOrderByUserIdUseCase } from "./domain/use-cases/get-order-by-user-id
   ],
   controllers: [OrderController, UserOrderController],
   providers: [
+    TransactionService,
     OrderApplicationService,
     CreateOrderUseCase,
     ApplyDiscountUseCase,
@@ -48,6 +73,30 @@ import { GetOrderByUserIdUseCase } from "./domain/use-cases/get-order-by-user-id
     {
       provide: "OrderItemRepositoryInterface",
       useClass: OrderItemRepository,
+    },
+    {
+      provide: "CouponRepositoryInterface",
+      useClass: CouponRepository,
+    },
+    {
+      provide: "UserCouponRepositoryInterface",
+      useClass: UserCouponRepository,
+    },
+    {
+      provide: "ProductRepositoryInterface",
+      useClass: ProductRepository,
+    },
+    {
+      provide: "StockReservationRepositoryInterface",
+      useClass: StockReservationRepository,
+    },
+    {
+      provide: "UserBalanceRepositoryInterface",
+      useClass: UserBalanceRepository,
+    },
+    {
+      provide: "PointTransactionRepositoryInterface",
+      useClass: PointTransactionRepository,
     },
   ],
   exports: [OrderApplicationService],

--- a/src/product/application/services/product.service.ts
+++ b/src/product/application/services/product.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { DataSource, EntityManager } from "typeorm";
 import { GetProductByIdUseCase } from "@/product/domain/use-cases/get-product-by-id.use-case";
 import { GetAllProductsUseCase } from "@/product/domain/use-cases/get-all-products.use-case";
@@ -24,8 +24,7 @@ import {
 } from "@/product/domain/use-cases/confirm-stock.use-case";
 import { StockReservation } from "@/product/domain/entities/stock-reservation.entity";
 import { GetProductByIdsUseCase } from "@/product/domain/use-cases/get-product-by-ids.use-case";
-import { ProductRepository } from "@/product/infrastructure/persistence/product.repository";
-import { StockReservationRepository } from "@/product/infrastructure/persistence/stock-reservations.repository";
+import { GetStockReservationsByKeyUseCase } from "@/product/domain/use-cases/get-stock-reservations-by-key.use-case";
 import { TransactionService } from "@/common/services/transaction.service";
 
 @Injectable()
@@ -37,7 +36,8 @@ export class ProductApplicationService {
     private readonly getAllProductsUseCase: GetAllProductsUseCase,
     private readonly reserveStockUseCase: ReserveStockUseCase,
     private readonly releaseStockUseCase: ReleaseStockUseCase,
-    private readonly confirmStockUseCase: ConfirmStockUseCase
+    private readonly confirmStockUseCase: ConfirmStockUseCase,
+    private readonly getStockReservationsByKeyUseCase: GetStockReservationsByKeyUseCase
   ) {}
 
   async getProductById(id: string): Promise<Product | null> {
@@ -93,5 +93,15 @@ export class ProductApplicationService {
   async getPopularProducts(limit?: number): Promise<any[]> {
     // TODO: Order 도메인 구현 진행 된 후에 구현 가능함.
     return [];
+  }
+
+  async getStockReservationIdsByIdempotencyKey(
+    idempotencyKey: string
+  ): Promise<string[]> {
+    const { stockReservations } =
+      await this.getStockReservationsByKeyUseCase.execute({
+        idempotencyKey,
+      });
+    return stockReservations.map((reservation) => reservation.id);
   }
 }

--- a/src/product/domain/interfaces/stock-reservation.repository.interface.ts
+++ b/src/product/domain/interfaces/stock-reservation.repository.interface.ts
@@ -3,4 +3,5 @@ import { StockReservation } from "../entities/stock-reservation.entity";
 export interface StockReservationRepositoryInterface {
   save(stockReservation: StockReservation): Promise<StockReservation>;
   findById(id: string): Promise<StockReservation | null>;
+  findByIdempotencyKey(idempotencyKey: string): Promise<StockReservation[]>;
 }

--- a/src/product/domain/use-cases/get-all-products.use-case.ts
+++ b/src/product/domain/use-cases/get-all-products.use-case.ts
@@ -2,7 +2,7 @@ import { Injectable, Inject } from "@nestjs/common";
 import { ProductRepositoryInterface } from "@/product/domain/interfaces/product.repository.interface";
 import { Product } from "@/product/domain/entities/product.entity";
 
-export interface GetAllProductsQuery {
+export interface GetAllProductsCommand {
   page?: number;
   limit?: number;
   search?: string;
@@ -24,14 +24,14 @@ export class GetAllProductsUseCase {
     private readonly productRepository: ProductRepositoryInterface
   ) {}
 
-  async execute(query: GetAllProductsQuery): Promise<GetAllProductsResult> {
-    const page = query.page || 1;
-    const limit = query.limit || 10;
+  async execute(command: GetAllProductsCommand): Promise<GetAllProductsResult> {
+    const page = command.page || 1;
+    const limit = command.limit || 10;
     const offset = (page - 1) * limit;
 
     const filters = {
-      isActive: query.isActive,
-      search: query.search,
+      isActive: command.isActive,
+      search: command.search,
     };
 
     const { products, total } = await this.productRepository.findPaginated(

--- a/src/product/domain/use-cases/get-stock-reservations-by-key.use-case.ts
+++ b/src/product/domain/use-cases/get-stock-reservations-by-key.use-case.ts
@@ -1,0 +1,32 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { StockReservationRepositoryInterface } from "../interfaces/stock-reservation.repository.interface";
+import { StockReservation } from "../entities/stock-reservation.entity";
+
+export interface GetStockReservationsByKeyUseCaseCommand {
+  idempotencyKey: string;
+}
+
+export interface GetStockReservationsByKeyUseCaseResult {
+  stockReservations: StockReservation[];
+}
+
+@Injectable()
+export class GetStockReservationsByKeyUseCase {
+  constructor(
+    @Inject("StockReservationRepositoryInterface")
+    private readonly stockReservationRepository: StockReservationRepositoryInterface
+  ) {}
+
+  async execute(
+    command: GetStockReservationsByKeyUseCaseCommand
+  ): Promise<GetStockReservationsByKeyUseCaseResult> {
+    const { idempotencyKey } = command;
+
+    const stockReservations =
+      await this.stockReservationRepository.findByIdempotencyKey(
+        idempotencyKey
+      );
+
+    return { stockReservations };
+  }
+}

--- a/src/product/domain/use-cases/reserve-stock.use-case.ts
+++ b/src/product/domain/use-cases/reserve-stock.use-case.ts
@@ -59,7 +59,6 @@ export class ReserveStockUseCase {
       idempotencyKey,
     });
 
-    // TODO: service 계층에서 transaction 처리 필요.
     await this.stockReservationRepository.save(stockReservation);
     await this.productRepository.save(product);
 

--- a/src/product/infrastructure/persistence/product.repository.ts
+++ b/src/product/infrastructure/persistence/product.repository.ts
@@ -1,37 +1,57 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { In, Repository } from "typeorm";
+import { In, Repository, EntityManager } from "typeorm";
 import { ProductRepositoryInterface } from "@/product/domain/interfaces/product.repository.interface";
 import { Product } from "@/product/domain/entities/product.entity";
 import { ProductTypeOrmEntity } from "./orm/product.typeorm.entity";
 
 @Injectable()
 export class ProductRepository implements ProductRepositoryInterface {
+  private entityManager?: EntityManager;
+
   constructor(
     @InjectRepository(ProductTypeOrmEntity)
     private readonly productRepository: Repository<ProductTypeOrmEntity>
   ) {}
 
+  setEntityManager(manager: EntityManager): void {
+    this.entityManager = manager;
+  }
+
+  clearEntityManager(): void {
+    this.entityManager = undefined;
+  }
+
+  private getRepository(): Repository<ProductTypeOrmEntity> {
+    return this.entityManager
+      ? this.entityManager.getRepository(ProductTypeOrmEntity)
+      : this.productRepository;
+  }
+
   async findById(id: string): Promise<Product | null> {
-    const entity = await this.productRepository.findOne({ where: { id } });
+    const repository = this.getRepository();
+    const entity = await repository.findOne({ where: { id } });
     return entity ? this.toDomain(entity) : null;
   }
 
   async findByIds(ids: string[]): Promise<Product[]> {
-    const entities = await this.productRepository.find({
+    const repository = this.getRepository();
+    const entities = await repository.find({
       where: { id: In(ids) },
     });
     return entities.map((entity) => this.toDomain(entity));
   }
 
   async findByName(name: string): Promise<Product | null> {
-    const entity = await this.productRepository.findOne({ where: { name } });
+    const repository = this.getRepository();
+    const entity = await repository.findOne({ where: { name } });
     return entity ? this.toDomain(entity) : null;
   }
 
   async save(product: Product): Promise<Product> {
+    const repository = this.getRepository();
     const entity = this.fromDomain(product);
-    const savedEntity = await this.productRepository.save(entity);
+    const savedEntity = await repository.save(entity);
     return this.toDomain(savedEntity);
   }
 
@@ -43,7 +63,8 @@ export class ProductRepository implements ProductRepositoryInterface {
       search?: string;
     }
   ): Promise<{ products: Product[]; total: number }> {
-    const queryBuilder = this.productRepository.createQueryBuilder("product");
+    const repository = this.getRepository();
+    const queryBuilder = repository.createQueryBuilder("product");
 
     // 활성화 상태 필터
     if (filters?.isActive !== undefined) {

--- a/src/product/infrastructure/persistence/product.repository.ts
+++ b/src/product/infrastructure/persistence/product.repository.ts
@@ -4,6 +4,7 @@ import { In, Repository, EntityManager } from "typeorm";
 import { ProductRepositoryInterface } from "@/product/domain/interfaces/product.repository.interface";
 import { Product } from "@/product/domain/entities/product.entity";
 import { ProductTypeOrmEntity } from "./orm/product.typeorm.entity";
+import { TransactionContext } from "@/common/services/transaction.service";
 
 @Injectable()
 export class ProductRepository implements ProductRepositoryInterface {
@@ -12,7 +13,9 @@ export class ProductRepository implements ProductRepositoryInterface {
   constructor(
     @InjectRepository(ProductTypeOrmEntity)
     private readonly productRepository: Repository<ProductTypeOrmEntity>
-  ) {}
+  ) {
+    TransactionContext.registerRepository(this);
+  }
 
   setEntityManager(manager: EntityManager): void {
     this.entityManager = manager;

--- a/src/product/infrastructure/persistence/stock-reservations.repository.ts
+++ b/src/product/infrastructure/persistence/stock-reservations.repository.ts
@@ -48,6 +48,16 @@ export class StockReservationRepository
     return entity ? this.toDomain(entity) : null;
   }
 
+  async findByIdempotencyKey(
+    idempotencyKey: string
+  ): Promise<StockReservation[]> {
+    const repository = this.getRepository();
+    const entities = await repository.find({
+      where: { idempotencyKey },
+    });
+    return entities.map((entity) => this.toDomain(entity));
+  }
+
   private fromDomain(
     stockReservation: StockReservation
   ): StockReservationTypeOrmEntity {

--- a/src/product/infrastructure/persistence/stock-reservations.repository.ts
+++ b/src/product/infrastructure/persistence/stock-reservations.repository.ts
@@ -4,6 +4,7 @@ import { Repository, EntityManager } from "typeorm";
 import { StockReservationRepositoryInterface } from "@/product/domain/interfaces/stock-reservation.repository.interface";
 import { StockReservationTypeOrmEntity } from "./orm/stock-reservations.typeorm.entity";
 import { StockReservation } from "@/product/domain/entities/stock-reservation.entity";
+import { TransactionContext } from "@/common/services/transaction.service";
 
 @Injectable()
 export class StockReservationRepository
@@ -14,7 +15,9 @@ export class StockReservationRepository
   constructor(
     @InjectRepository(StockReservationTypeOrmEntity)
     private readonly stockReservationRepository: Repository<StockReservationTypeOrmEntity>
-  ) {}
+  ) {
+    TransactionContext.registerRepository(this);
+  }
 
   setEntityManager(manager: EntityManager): void {
     this.entityManager = manager;

--- a/src/product/infrastructure/persistence/stock-reservations.repository.ts
+++ b/src/product/infrastructure/persistence/stock-reservations.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import { Repository, EntityManager } from "typeorm";
 import { StockReservationRepositoryInterface } from "@/product/domain/interfaces/stock-reservation.repository.interface";
 import { StockReservationTypeOrmEntity } from "./orm/stock-reservations.typeorm.entity";
 import { StockReservation } from "@/product/domain/entities/stock-reservation.entity";
@@ -9,19 +9,37 @@ import { StockReservation } from "@/product/domain/entities/stock-reservation.en
 export class StockReservationRepository
   implements StockReservationRepositoryInterface
 {
+  private entityManager?: EntityManager;
+
   constructor(
     @InjectRepository(StockReservationTypeOrmEntity)
     private readonly stockReservationRepository: Repository<StockReservationTypeOrmEntity>
   ) {}
 
+  setEntityManager(manager: EntityManager): void {
+    this.entityManager = manager;
+  }
+
+  clearEntityManager(): void {
+    this.entityManager = undefined;
+  }
+
+  private getRepository(): Repository<StockReservationTypeOrmEntity> {
+    return this.entityManager
+      ? this.entityManager.getRepository(StockReservationTypeOrmEntity)
+      : this.stockReservationRepository;
+  }
+
   async save(stockReservation: StockReservation): Promise<StockReservation> {
+    const repository = this.getRepository();
     const entity = this.fromDomain(stockReservation);
-    const savedEntity = await this.stockReservationRepository.save(entity);
+    const savedEntity = await repository.save(entity);
     return this.toDomain(savedEntity);
   }
 
   async findById(id: string): Promise<StockReservation | null> {
-    const entity = await this.stockReservationRepository.findOne({
+    const repository = this.getRepository();
+    const entity = await repository.findOne({
       where: { id },
     });
     return entity ? this.toDomain(entity) : null;

--- a/src/product/product.module.ts
+++ b/src/product/product.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { ProductController } from "./infrastructure/http/product.controller";
+import { TransactionService } from "../common/services/transaction.service";
 import { ProductApplicationService } from "./application/services/product.service";
 import { ProductRepository } from "./infrastructure/persistence/product.repository";
 import { ProductTypeOrmEntity } from "./infrastructure/persistence/orm/product.typeorm.entity";
@@ -24,6 +25,7 @@ import { StockReservationRepository } from "./infrastructure/persistence/stock-r
   ],
   controllers: [ProductController],
   providers: [
+    TransactionService,
     ProductApplicationService,
     GetProductByIdUseCase,
     GetProductByIdsUseCase,
@@ -40,6 +42,12 @@ import { StockReservationRepository } from "./infrastructure/persistence/stock-r
       useClass: StockReservationRepository,
     },
   ],
-  exports: [ProductApplicationService],
+  exports: [
+    ProductApplicationService,
+    {
+      provide: "StockReservationRepositoryInterface",
+      useClass: StockReservationRepository,
+    },
+  ],
 })
 export class ProductModule {}

--- a/src/product/product.module.ts
+++ b/src/product/product.module.ts
@@ -11,6 +11,7 @@ import { GetAllProductsUseCase } from "./domain/use-cases/get-all-products.use-c
 import { ReserveStockUseCase } from "./domain/use-cases/reserve-stock.use-case";
 import { ReleaseStockUseCase } from "./domain/use-cases/release-stock.use-case";
 import { ConfirmStockUseCase } from "./domain/use-cases/confirm-stock.use-case";
+import { GetStockReservationsByKeyUseCase } from "./domain/use-cases/get-stock-reservations-by-key.use-case";
 import { AuthModule } from "../auth/auth.module";
 import { StockReservationTypeOrmEntity } from "./infrastructure/persistence/orm/stock-reservations.typeorm.entity";
 import { StockReservationRepository } from "./infrastructure/persistence/stock-reservations.repository";
@@ -33,6 +34,7 @@ import { StockReservationRepository } from "./infrastructure/persistence/stock-r
     ReserveStockUseCase,
     ReleaseStockUseCase,
     ConfirmStockUseCase,
+    GetStockReservationsByKeyUseCase,
     {
       provide: "ProductRepositoryInterface",
       useClass: ProductRepository,

--- a/src/user/infrastructure/persistence/user.repository.ts
+++ b/src/user/infrastructure/persistence/user.repository.ts
@@ -4,6 +4,7 @@ import { Repository, EntityManager } from "typeorm";
 import { UserRepositoryInterface } from "@/user/domain/interfaces/user.repository.interface";
 import { User } from "@/user/domain/entities/user.entity";
 import { UserTypeOrmEntity } from "./orm/user.typeorm.entity";
+import { TransactionContext } from "@/common/services/transaction.service";
 
 @Injectable()
 export class UserRepository implements UserRepositoryInterface {
@@ -12,7 +13,9 @@ export class UserRepository implements UserRepositoryInterface {
   constructor(
     @InjectRepository(UserTypeOrmEntity)
     private readonly userRepository: Repository<UserTypeOrmEntity>
-  ) {}
+  ) {
+    TransactionContext.registerRepository(this);
+  }
 
   setEntityManager(manager: EntityManager): void {
     this.entityManager = manager;

--- a/src/user/infrastructure/persistence/user.repository.ts
+++ b/src/user/infrastructure/persistence/user.repository.ts
@@ -1,35 +1,55 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import { Repository, EntityManager } from "typeorm";
 import { UserRepositoryInterface } from "@/user/domain/interfaces/user.repository.interface";
 import { User } from "@/user/domain/entities/user.entity";
 import { UserTypeOrmEntity } from "./orm/user.typeorm.entity";
 
 @Injectable()
 export class UserRepository implements UserRepositoryInterface {
+  private entityManager?: EntityManager;
+
   constructor(
     @InjectRepository(UserTypeOrmEntity)
     private readonly userRepository: Repository<UserTypeOrmEntity>
   ) {}
 
+  setEntityManager(manager: EntityManager): void {
+    this.entityManager = manager;
+  }
+
+  clearEntityManager(): void {
+    this.entityManager = undefined;
+  }
+
+  private getRepository(): Repository<UserTypeOrmEntity> {
+    return this.entityManager
+      ? this.entityManager.getRepository(UserTypeOrmEntity)
+      : this.userRepository;
+  }
+
   async findById(id: string): Promise<User | null> {
-    const entity = await this.userRepository.findOne({ where: { id } });
+    const repository = this.getRepository();
+    const entity = await repository.findOne({ where: { id } });
     return entity ? this.toDomain(entity) : null;
   }
 
   async findByEmail(email: string): Promise<User | null> {
-    const entity = await this.userRepository.findOne({ where: { email } });
+    const repository = this.getRepository();
+    const entity = await repository.findOne({ where: { email } });
     return entity ? this.toDomain(entity) : null;
   }
 
   async save(user: User): Promise<User> {
+    const repository = this.getRepository();
     const entity = this.fromDomain(user);
-    const savedEntity = await this.userRepository.save(entity);
+    const savedEntity = await repository.save(entity);
     return this.toDomain(savedEntity);
   }
 
   async exists(email: string): Promise<boolean> {
-    const count = await this.userRepository.count({ where: { email } });
+    const repository = this.getRepository();
+    const count = await repository.count({ where: { email } });
     return count > 0;
   }
 

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -9,6 +9,7 @@ import { GetUserByEmailUseCase } from "./domain/use-cases/get-user-by-email.use-
 import { CreateUserUseCase } from "./domain/use-cases/create-user.use-case";
 import { AuthModule } from "@/auth/auth.module";
 import { WalletModule } from "@/wallet/wallet.module";
+import { TransactionService } from "@/common/services/transaction.service";
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { WalletModule } from "@/wallet/wallet.module";
   ],
   controllers: [UserController],
   providers: [
+    TransactionService,
     UserApplicationService,
     GetUserByIdUseCase,
     GetUserByEmailUseCase,

--- a/src/wallet/application/wallet.service.ts
+++ b/src/wallet/application/wallet.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Inject } from "@nestjs/common";
+import { DataSource } from "typeorm";
 import {
   ChargePointsUseCase,
   ChargePointsUseCaseResult,
@@ -23,10 +24,17 @@ import {
   ValidateUsePointsUseCase,
   ValidateUsePointsUseCaseResult,
 } from "../domain/use-cases/validate-use-points.use-case";
+import { UserBalanceRepository } from "../infrastructure/persistence/use-balance.repository";
+import { PointTransactionRepository } from "../infrastructure/persistence/point-transaction.repository";
 
 @Injectable()
 export class WalletApplicationService {
   constructor(
+    private readonly dataSource: DataSource,
+    @Inject("UserBalanceRepositoryInterface")
+    private readonly userBalanceRepository: UserBalanceRepository,
+    @Inject("PointTransactionRepositoryInterface")
+    private readonly pointTransactionRepository: PointTransactionRepository,
     private readonly chargePointsUseCase: ChargePointsUseCase,
     private readonly usePointsUseCase: UsePointsUseCase,
     private readonly recoverPointsUseCase: RecoverPointsUseCase,
@@ -40,13 +48,13 @@ export class WalletApplicationService {
     amount: number,
     idempotencyKey: string
   ): Promise<ChargePointsUseCaseResult> {
-    // TODO: 외부 결제 api 검증 호출
-    const result = await this.chargePointsUseCase.execute({
-      userId,
-      amount,
-      idempotencyKey,
-    }); // TODO: 트랜잭션으로 묶어서 동시에 outbox payment 테이블에 등록 => 외부/다른곳에서 알아서 비동기로 결제 호출
-    return result;
+    return await this.executeInTransaction(async () => {
+      return await this.chargePointsUseCase.execute({
+        userId,
+        amount,
+        idempotencyKey,
+      });
+    });
   }
 
   async usePoints(
@@ -54,13 +62,13 @@ export class WalletApplicationService {
     amount: number,
     idempotencyKey: string
   ): Promise<UsePointsUseCaseResult> {
-    const result = await this.usePointsUseCase.execute({
-      userId,
-      amount,
-      idempotencyKey,
+    return await this.executeInTransaction(async () => {
+      return await this.usePointsUseCase.execute({
+        userId,
+        amount,
+        idempotencyKey,
+      });
     });
-
-    return result;
   }
 
   async recoverPoints(
@@ -68,35 +76,47 @@ export class WalletApplicationService {
     amount: number,
     idempotencyKey: string
   ): Promise<RecoverPointsUseCaseResult> {
-    const result = await this.recoverPointsUseCase.execute({
-      userId,
-      amount,
-      idempotencyKey,
+    return await this.executeInTransaction(async () => {
+      return await this.recoverPointsUseCase.execute({
+        userId,
+        amount,
+        idempotencyKey,
+      });
     });
-
-    return result;
   }
 
   async getUserPoints(userId: string): Promise<GetUserPointsUseCaseResult> {
-    const result = await this.getUserPointsUseCase.execute({ userId });
-    return result;
+    return await this.getUserPointsUseCase.execute({ userId });
   }
 
   async createUserBalance(
     userId: string
   ): Promise<CreateUserBalanceUseCaseResult> {
-    const result = await this.createUserBalanceUseCase.execute({ userId });
-    return result;
+    return await this.executeInTransaction(async () => {
+      return await this.createUserBalanceUseCase.execute({ userId });
+    });
   }
 
   async validateUsePoints(
     userId: string,
     amount: number
   ): Promise<ValidateUsePointsUseCaseResult> {
-    const result = await this.validateUsePointsUseCase.execute({
-      userId,
-      amount,
+    return await this.validateUsePointsUseCase.execute({ userId, amount });
+  }
+
+  private async executeInTransaction<T>(
+    operation: () => Promise<T>
+  ): Promise<T> {
+    return await this.dataSource.transaction(async (manager) => {
+      this.userBalanceRepository.setEntityManager(manager);
+      this.pointTransactionRepository.setEntityManager(manager);
+
+      try {
+        return await operation();
+      } finally {
+        this.userBalanceRepository.clearEntityManager();
+        this.pointTransactionRepository.clearEntityManager();
+      }
     });
-    return result;
   }
 }

--- a/src/wallet/infrastructure/persistence/point-transaction.repository.ts
+++ b/src/wallet/infrastructure/persistence/point-transaction.repository.ts
@@ -7,6 +7,7 @@ import {
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository, EntityManager } from "typeorm";
 import { PointTransaction } from "@/wallet/domain/entities/point-transaction.entity";
+import { TransactionContext } from "@/common/services/transaction.service";
 
 @Injectable()
 export class PointTransactionRepository
@@ -17,7 +18,9 @@ export class PointTransactionRepository
   constructor(
     @InjectRepository(PointTransactionTypeOrmEntity)
     private readonly pointTransactionRepository: Repository<PointTransactionTypeOrmEntity>
-  ) {}
+  ) {
+    TransactionContext.registerRepository(this);
+  }
 
   setEntityManager(manager: EntityManager): void {
     this.entityManager = manager;

--- a/src/wallet/infrastructure/persistence/use-balance.repository.ts
+++ b/src/wallet/infrastructure/persistence/use-balance.repository.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Repository, EntityManager } from "typeorm";
 import { UserBalanceTypeOrmEntity } from "./orm/user-balance.typeorm.entity";
 import { UserBalance } from "@/wallet/domain/entities/user-balance.entity";
+import { TransactionContext } from "@/common/services/transaction.service";
 
 @Injectable()
 export class UserBalanceRepository implements UserBalanceRepositoryInterface {
@@ -12,7 +13,9 @@ export class UserBalanceRepository implements UserBalanceRepositoryInterface {
   constructor(
     @InjectRepository(UserBalanceTypeOrmEntity)
     private readonly userBalanceRepository: Repository<UserBalanceTypeOrmEntity>
-  ) {}
+  ) {
+    TransactionContext.registerRepository(this);
+  }
 
   setEntityManager(manager: EntityManager): void {
     this.entityManager = manager;

--- a/src/wallet/infrastructure/persistence/use-balance.repository.ts
+++ b/src/wallet/infrastructure/persistence/use-balance.repository.ts
@@ -1,27 +1,45 @@
 import { UserBalanceRepositoryInterface } from "@/wallet/domain/interfaces/user-balance.repository";
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import { Repository, EntityManager } from "typeorm";
 import { UserBalanceTypeOrmEntity } from "./orm/user-balance.typeorm.entity";
 import { UserBalance } from "@/wallet/domain/entities/user-balance.entity";
 
 @Injectable()
 export class UserBalanceRepository implements UserBalanceRepositoryInterface {
+  private entityManager?: EntityManager;
+
   constructor(
     @InjectRepository(UserBalanceTypeOrmEntity)
     private readonly userBalanceRepository: Repository<UserBalanceTypeOrmEntity>
   ) {}
 
+  setEntityManager(manager: EntityManager): void {
+    this.entityManager = manager;
+  }
+
+  clearEntityManager(): void {
+    this.entityManager = undefined;
+  }
+
+  private getRepository(): Repository<UserBalanceTypeOrmEntity> {
+    return this.entityManager
+      ? this.entityManager.getRepository(UserBalanceTypeOrmEntity)
+      : this.userBalanceRepository;
+  }
+
   async findByUserId(userId: string): Promise<UserBalance | null> {
-    const entity = await this.userBalanceRepository.findOne({
+    const repository = this.getRepository();
+    const entity = await repository.findOne({
       where: { userId },
     });
     return entity ? this.toDomain(entity) : null;
   }
 
   async save(userBalance: UserBalance): Promise<UserBalance> {
+    const repository = this.getRepository();
     const entity = this.fromDomain(userBalance);
-    const savedEntity = await this.userBalanceRepository.save(entity);
+    const savedEntity = await repository.save(entity);
     return this.toDomain(savedEntity);
   }
 

--- a/src/wallet/wallet.module.ts
+++ b/src/wallet/wallet.module.ts
@@ -1,6 +1,7 @@
 import { Module, forwardRef } from "@nestjs/common";
 import { WalletController } from "./infrastructure/http/wallet.controller";
 import { AuthModule } from "../auth/auth.module";
+import { TransactionService } from "../common/services/transaction.service";
 import { UserBalanceRepository } from "./infrastructure/persistence/use-balance.repository";
 import { PointTransactionRepository } from "./infrastructure/persistence/point-transaction.repository";
 import { WalletApplicationService } from "./application/wallet.service";
@@ -24,6 +25,7 @@ import { TypeOrmModule } from "@nestjs/typeorm";
   ],
   controllers: [WalletController],
   providers: [
+    TransactionService,
     WalletApplicationService,
     ChargePointsUseCase,
     RecoverPointsUseCase,


### PR DESCRIPTION
### 💬 배경

- transaction 처리를 위한 모듈들을 구현합니다.
- transaction 처리는 오로지 application 계층에서만 일어나도록 설정해놓았습니다.

### 📚 핵심 커밋 로그

- 도메인 별 transaction 구현 [31c4e6e](https://github.com/seho0808/hh-9-be-2/pull/15/commits/31c4e6eabe22bc4e1f72c65e765cde9bb4a85475) [609131c](https://github.com/seho0808/hh-9-be-2/pull/15/commits/609131c5d2d407ae2ddc174d953ef1cbddb51599) [057c91d](https://github.com/seho0808/hh-9-be-2/pull/15/commits/057c91dde5b7c0635ce91eb272f03c17a3663334) [d30e6cb](https://github.com/seho0808/hh-9-be-2/pull/15/commits/d30e6cb74c9e0d191a8acef13fe0bfc4ae9bbac4)
- 간결하게 리팩토링: [b5a9162](https://github.com/seho0808/hh-9-be-2/pull/15/commits/b5a91625419fcb0d94d71191d2539b853eaef398) [cb82823](https://github.com/seho0808/hh-9-be-2/pull/15/commits/cb8282341d2ce2041773e6a848c5b27d514d2f55)
- order transaction 구현: [f0e5c88](https://github.com/seho0808/hh-9-be-2/pull/15/commits/f0e5c8847675923dbd0e7fc6f5a45d7ecd80da0a)
- 다시 리팩토링: [754a28a](https://github.com/seho0808/hh-9-be-2/pull/15/commits/754a28acc1ce2e8a09317901bb449f00406502fe)

그 다음에 보상 트랜잭션 쪽 크론잡 failover 구현 [1d92f54](https://github.com/seho0808/hh-9-be-2/pull/15/commits/1d92f54c0de7bfee51c1e3a2b8805847c57e24c2) [3d2217a](https://github.com/seho0808/hh-9-be-2/pull/15/commits/3d2217a0dcd0a0ecfb4c7a66d4acf9725991bd0b) [139309e](https://github.com/seho0808/hh-9-be-2/pull/15/commits/139309ea8abf6b399c98da433c070af27c176573)


### 🤔 고민 포인트

- stock 복구할 때 id들을 가져오는 과정에서 n번 쿼리를 날리는 오류가 있는데 리팩토링 할 시간이 없어서 일단 스킵 ([65a81bc](https://github.com/seho0808/hh-9-be-2/pull/15/commits/65a81bca68209e0b28fc35a90a0f123c76562df8))
  - 이거 구현하면서 느낀점 - transaction 구성이랑 usecase를 구성하는 로직이 서로 상충함. domain 계층의 domain-service인 usecase는 외부 구현을 몰라야하는 것이 이상적인데, transaction을 위해서 어쩔 수 없이 usecase 구조를 타협해야함. 즉, 서로 최대한 분리하게 설계하는 것은 domain 계층의 testability 때문이며 db transaction이라는 제한사항 때문에 유스케이스의 형태가 영향을 받을 수 밖에 없음.