### PR TITLE
fix: 재고, 쿠폰, 충전 관리 idempotencyKey => refId, orderId로 변경

### DIFF
--- a/src/coupon/application/use-cases/tier-1-in-domain/cancel-user-coupon.use-case.spec.ts
+++ b/src/coupon/application/use-cases/tier-1-in-domain/cancel-user-coupon.use-case.spec.ts
@@ -101,7 +101,7 @@ describe("CancelUserCouponUseCase", () => {
 
       // NOTE: 다른 유스케이스 가져다가 써야할수도
       const { discountPrice } = coupon.use(50000);
-      userCoupon.use("order-1", discountPrice, uuidv4());
+      userCoupon.use("order-1", discountPrice);
 
       const initialUsedCount = coupon.usedCount;
 

--- a/src/coupon/application/use-cases/tier-1-in-domain/recover-user-coupon.use-case.ts
+++ b/src/coupon/application/use-cases/tier-1-in-domain/recover-user-coupon.use-case.ts
@@ -5,7 +5,7 @@ import { UserCouponRepository } from "@/coupon/infrastructure/persistence/user-c
 
 export interface RecoverUserCouponCommand {
   userCouponId: string;
-  idempotencyKey: string;
+  orderId: string;
 }
 
 export interface RecoverUserCouponResult {
@@ -19,14 +19,14 @@ export class RecoverUserCouponUseCase {
   async execute(
     command: RecoverUserCouponCommand
   ): Promise<RecoverUserCouponResult> {
-    const { userCouponId, idempotencyKey } = command;
+    const { userCouponId, orderId } = command;
 
     const userCoupon = await this.userCouponRepository.findById(userCouponId);
     if (!userCoupon) {
       throw new UserCouponNotFoundError(userCouponId);
     }
 
-    userCoupon.recover(idempotencyKey);
+    userCoupon.recover(orderId);
 
     await this.userCouponRepository.save(userCoupon);
 

--- a/src/coupon/application/use-cases/tier-1-in-domain/use-user-coupon.use-case.spec.ts
+++ b/src/coupon/application/use-cases/tier-1-in-domain/use-user-coupon.use-case.spec.ts
@@ -77,7 +77,6 @@ describe("UseUserCouponUseCase", () => {
           userId: userCoupon.userId,
           orderId,
           orderPrice: 60000,
-          idempotencyKey: uuidv4(),
         });
 
         expect(result.discountPrice).toBe(10000);
@@ -123,7 +122,6 @@ describe("UseUserCouponUseCase", () => {
           userId: userCoupon.userId,
           orderId: uuidv4(),
           orderPrice: 100000, // 50% = 50000원이지만 최대 20000원으로 제한
-          idempotencyKey: uuidv4(),
         });
 
         expect(result.discountPrice).toBe(20000);
@@ -162,7 +160,6 @@ describe("UseUserCouponUseCase", () => {
           userId: userCoupon.userId,
           orderId: uuidv4(),
           orderPrice: 100000,
-          idempotencyKey: uuidv4(),
         });
 
         expect(result.discountPrice).toBe(30000);
@@ -201,7 +198,6 @@ describe("UseUserCouponUseCase", () => {
           userId: userCoupon.userId,
           orderId: uuidv4(),
           orderPrice: 1235, // 10% = 123.5원 → 123원 (소수점 버림)
-          idempotencyKey: uuidv4(),
         });
 
         expect(result.discountPrice).toBe(123); // 123.5가 아닌 123원
@@ -221,7 +217,6 @@ describe("UseUserCouponUseCase", () => {
           userId: uuidv4(),
           orderId: uuidv4(),
           orderPrice: 10000,
-          idempotencyKey: uuidv4(),
         })
       ).rejects.toThrow(CouponNotFoundError);
     });
@@ -259,7 +254,6 @@ describe("UseUserCouponUseCase", () => {
           userId: expiredUserCoupon.userId,
           orderId: uuidv4(),
           orderPrice: 60000,
-          idempotencyKey: uuidv4(),
         })
       ).rejects.toThrow(UserCouponExpiredError);
     });
@@ -286,7 +280,7 @@ describe("UseUserCouponUseCase", () => {
         issuedIdempotencyKey: uuidv4(),
       });
 
-      userCoupon.use("previous-order", 10000, uuidv4());
+      userCoupon.use("previous-order", 10000);
 
       couponRepository.findById.mockResolvedValue(coupon);
       userCouponRepository.findByCouponIdAndUserId.mockResolvedValue(
@@ -299,7 +293,6 @@ describe("UseUserCouponUseCase", () => {
           userId: userCoupon.userId,
           orderId: uuidv4(),
           orderPrice: 60000,
-          idempotencyKey: uuidv4(),
         })
       ).rejects.toThrow(UserCouponAlreadyUsedError);
     });
@@ -339,7 +332,6 @@ describe("UseUserCouponUseCase", () => {
           userId: userCoupon.userId,
           orderId: uuidv4(),
           orderPrice: 60000,
-          idempotencyKey: uuidv4(),
         })
       ).rejects.toThrow(UserCouponCancelledError);
     });

--- a/src/coupon/application/use-cases/tier-1-in-domain/use-user-coupon.use-case.ts
+++ b/src/coupon/application/use-cases/tier-1-in-domain/use-user-coupon.use-case.ts
@@ -11,7 +11,6 @@ export interface UseUserCouponCommand {
   userId: string;
   orderId: string;
   orderPrice: number;
-  idempotencyKey: string;
 }
 
 export interface UseUserCouponResult {
@@ -30,7 +29,7 @@ export class UseUserCouponUseCase {
 
   @Transactional()
   async execute(command: UseUserCouponCommand): Promise<UseUserCouponResult> {
-    const { couponId, userId, orderId, orderPrice, idempotencyKey } = command;
+    const { couponId, userId, orderId, orderPrice } = command;
 
     const coupon = await this.couponRepository.findById(couponId);
     if (!coupon) {
@@ -43,7 +42,7 @@ export class UseUserCouponUseCase {
     );
 
     const { discountPrice, discountedPrice } = coupon.use(orderPrice);
-    userCoupon.use(orderId, discountPrice, idempotencyKey);
+    userCoupon.use(orderId, discountPrice);
 
     await Promise.all([
       this.couponRepository.save(coupon),

--- a/src/coupon/application/use-cases/tier-1-in-domain/validate-user-coupon.use-case.spec.ts
+++ b/src/coupon/application/use-cases/tier-1-in-domain/validate-user-coupon.use-case.spec.ts
@@ -257,7 +257,7 @@ describe("ValidateCouponUseCase", () => {
         issuedIdempotencyKey: uuidv4(),
       });
 
-      usedUserCoupon.use("order-1", 10000, uuidv4()); // 쿠폰 사용 처리
+      usedUserCoupon.use("order-1", 10000); // 쿠폰 사용 처리
 
       couponRepository.findById.mockResolvedValue(coupon);
       userCouponRepository.findByCouponIdAndUserId.mockResolvedValue(

--- a/src/coupon/domain/exceptions/user-coupon.exception.ts
+++ b/src/coupon/domain/exceptions/user-coupon.exception.ts
@@ -32,12 +32,12 @@ export class UserCouponNotFoundError extends CouponDomainError {
   }
 }
 
-export class UserCouponRecoverIdempotencyKeyMismatchError extends CouponDomainError {
-  readonly code = "USER_COUPON_RECOVER_IDEMPOTENCY_KEY_MISMATCH";
+export class UserCouponRecoverOrderIdMismatchError extends CouponDomainError {
+  readonly code = "USER_COUPON_RECOVER_ORDER_ID_MISMATCH";
 
-  constructor(userCouponId: string, idempotencyKey: string) {
+  constructor(userCouponId: string, orderId: string) {
     super(
-      `쿠폰 복구를 위한 멱등성 키가 일치하지 않습니다. ID: ${userCouponId}, 키: ${idempotencyKey}`
+      `쿠폰 복구를 위한 주문 ID가 일치하지 않습니다. ID: ${userCouponId}, 주문 ID: ${orderId}`
     );
   }
 }

--- a/src/coupon/infrastructure/persistence/orm/user-coupon.typeorm.entity.ts
+++ b/src/coupon/infrastructure/persistence/orm/user-coupon.typeorm.entity.ts
@@ -48,9 +48,6 @@ export class UserCouponTypeOrmEntity {
   @Column({ type: "varchar", name: "issued_idempotency_key", nullable: true })
   issuedIdempotencyKey: string | null;
 
-  @Column({ type: "varchar", name: "used_idempotency_key", nullable: true })
-  usedIdempotencyKey: string | null;
-
   @Column({ type: "timestamp", name: "expires_at" })
   @Index("idx_user_coupons_expires_at")
   expiresAt: Date;

--- a/src/coupon/infrastructure/persistence/user-coupon.repository.ts
+++ b/src/coupon/infrastructure/persistence/user-coupon.repository.ts
@@ -53,7 +53,6 @@ export class UserCouponRepository {
     entity.discountPrice = userCoupon.discountPrice;
     entity.status = userCoupon.status;
     entity.issuedIdempotencyKey = userCoupon.issuedIdempotencyKey;
-    entity.usedIdempotencyKey = userCoupon.usedIdempotencyKey;
     entity.expiresAt = userCoupon.expiresAt;
     entity.usedAt = userCoupon.usedAt;
     entity.cancelledAt = userCoupon.cancelledAt;
@@ -71,7 +70,6 @@ export class UserCouponRepository {
       discountPrice: entity.discountPrice,
       status: entity.status as UserCouponStatus,
       issuedIdempotencyKey: entity.issuedIdempotencyKey,
-      usedIdempotencyKey: entity.usedIdempotencyKey,
       expiresAt: entity.expiresAt,
       usedAt: entity.usedAt,
       cancelledAt: entity.cancelledAt,

--- a/src/order/application/use-cases/tier-1-in-domain/apply-discount.use-case.spec.ts
+++ b/src/order/application/use-cases/tier-1-in-domain/apply-discount.use-case.spec.ts
@@ -54,7 +54,7 @@ describe("ApplyDiscountUseCase", () => {
           idempotencyKey: uuidv4(),
         });
 
-        const appliedCouponId = uuidv4();
+        const appliedUserCouponId = uuidv4();
         const orderId = mockOrder.id;
 
         orderRepository.findById.mockResolvedValue(mockOrder);
@@ -62,7 +62,7 @@ describe("ApplyDiscountUseCase", () => {
         // when
         const result = await useCase.execute({
           orderId,
-          appliedCouponId,
+          appliedUserCouponId,
           discountPrice,
           discountedPrice,
         });
@@ -70,7 +70,7 @@ describe("ApplyDiscountUseCase", () => {
         // then
         expect(result.order.discountPrice).toBe(discountPrice);
         expect(result.order.finalPrice).toBe(discountedPrice);
-        expect(result.order.appliedCouponId).toBe(appliedCouponId);
+        expect(result.order.appliedUserCouponId).toBe(appliedUserCouponId);
         expect(result.order.totalPrice).toBe(totalPrice); // 원가는 변경되지 않음
         expect(result.order.updatedAt).toBeInstanceOf(Date);
       });
@@ -86,7 +86,7 @@ describe("ApplyDiscountUseCase", () => {
     await expect(
       useCase.execute({
         orderId: nonExistentOrderId,
-        appliedCouponId: uuidv4(),
+        appliedUserCouponId: uuidv4(),
         discountPrice: 1000,
         discountedPrice: 9000,
       })
@@ -106,7 +106,7 @@ describe("ApplyDiscountUseCase", () => {
 
     // 첫 번째 할인 적용
     mockOrder.applyDiscount({
-      appliedCouponId: "old-coupon",
+      appliedUserCouponId: "old-coupon",
       discountPrice: 2000,
       discountedPrice: 18000,
     });
@@ -117,13 +117,13 @@ describe("ApplyDiscountUseCase", () => {
     // when
     const result = await useCase.execute({
       orderId: mockOrder.id,
-      appliedCouponId: newCouponId,
+      appliedUserCouponId: newCouponId,
       discountPrice: 5000,
       discountedPrice: 15000,
     });
 
     // then
-    expect(result.order.appliedCouponId).toBe(newCouponId);
+    expect(result.order.appliedUserCouponId).toBe(newCouponId);
     expect(result.order.discountPrice).toBe(5000);
     expect(result.order.finalPrice).toBe(15000);
   });
@@ -144,7 +144,7 @@ describe("ApplyDiscountUseCase", () => {
     // when
     const result = await useCase.execute({
       orderId: mockOrder.id,
-      appliedCouponId: uuidv4(),
+      appliedUserCouponId: uuidv4(),
       discountPrice: 1000,
       discountedPrice: 9000,
     });

--- a/src/order/application/use-cases/tier-1-in-domain/apply-discount.use-case.ts
+++ b/src/order/application/use-cases/tier-1-in-domain/apply-discount.use-case.ts
@@ -5,7 +5,7 @@ import { OrderRepository } from "@/order/infrastructure/persistence/order.reposi
 
 export interface ApplyDiscountUseCaseCommand {
   orderId: string;
-  appliedCouponId: string;
+  appliedUserCouponId: string;
   discountPrice: number;
   discountedPrice: number;
 }
@@ -21,7 +21,7 @@ export class ApplyDiscountUseCase {
   async execute(
     command: ApplyDiscountUseCaseCommand
   ): Promise<ApplyDiscountUseCaseResult> {
-    const { orderId, appliedCouponId, discountPrice, discountedPrice } =
+    const { orderId, appliedUserCouponId, discountPrice, discountedPrice } =
       command;
 
     const order = await this.orderRepository.findById(orderId);
@@ -30,7 +30,7 @@ export class ApplyDiscountUseCase {
     }
 
     order.applyDiscount({
-      appliedCouponId,
+      appliedUserCouponId,
       discountPrice,
       discountedPrice,
     });

--- a/src/order/application/use-cases/tier-1-in-domain/change-order-status.use-case.spec.ts
+++ b/src/order/application/use-cases/tier-1-in-domain/change-order-status.use-case.spec.ts
@@ -156,7 +156,7 @@ describe("ChangeOrderStatusUseCase", () => {
 
     // 할인 적용
     mockOrder.applyDiscount({
-      appliedCouponId: "test-coupon",
+      appliedUserCouponId: "test-coupon",
       discountPrice: 1000,
       discountedPrice: 14000,
     });
@@ -166,7 +166,7 @@ describe("ChangeOrderStatusUseCase", () => {
     const originalTotalPrice = mockOrder.totalPrice;
     const originalDiscountPrice = mockOrder.discountPrice;
     const originalFinalPrice = mockOrder.finalPrice;
-    const originalAppliedCouponId = mockOrder.appliedCouponId;
+    const originalappliedUserCouponId = mockOrder.appliedUserCouponId;
     const originalIdempotencyKey = mockOrder.idempotencyKey;
 
     orderRepository.findById.mockResolvedValue(mockOrder);
@@ -183,7 +183,7 @@ describe("ChangeOrderStatusUseCase", () => {
     expect(result.order.totalPrice).toBe(originalTotalPrice);
     expect(result.order.discountPrice).toBe(originalDiscountPrice);
     expect(result.order.finalPrice).toBe(originalFinalPrice);
-    expect(result.order.appliedCouponId).toBe(originalAppliedCouponId);
+    expect(result.order.appliedUserCouponId).toBe(originalappliedUserCouponId);
     expect(result.order.idempotencyKey).toBe(originalIdempotencyKey);
   });
 });

--- a/src/order/application/use-cases/tier-1-in-domain/create-order.use-case.spec.ts
+++ b/src/order/application/use-cases/tier-1-in-domain/create-order.use-case.spec.ts
@@ -116,7 +116,7 @@ describe("CreateOrderUseCase", () => {
     // then
     expect(result.order.status).toBe(OrderStatus.PENDING);
     expect(result.order.discountPrice).toBe(0);
-    expect(result.order.appliedCouponId).toBeNull();
+    expect(result.order.appliedUserCouponId).toBeNull();
     expect(result.order.id).toBeDefined();
     expect(result.order.createdAt).toBeInstanceOf(Date);
     expect(result.order.updatedAt).toBeInstanceOf(Date);

--- a/src/order/application/use-cases/tier-2/process-order.use-case.ts
+++ b/src/order/application/use-cases/tier-2/process-order.use-case.ts
@@ -59,7 +59,6 @@ export class ProcessOrderUseCase {
         userId,
         orderId: order.id,
         orderPrice: order.totalPrice,
-        idempotencyKey,
       });
     }
 
@@ -69,6 +68,7 @@ export class ProcessOrderUseCase {
       userId,
       amount: finalAmountToPay,
       idempotencyKey,
+      refId: order.id,
     });
 
     // 재고 확정
@@ -77,7 +77,7 @@ export class ProcessOrderUseCase {
       stockReservationIds.map((stockReservationId) =>
         this.confirmStockUseCase.execute({
           stockReservationId,
-          idempotencyKey,
+          orderId: order.id,
         })
       )
     );

--- a/src/order/application/use-cases/tier-2/process-order.use-case.ts
+++ b/src/order/application/use-cases/tier-2/process-order.use-case.ts
@@ -48,7 +48,7 @@ export class ProcessOrderUseCase {
       const { order: discountedOrder } =
         await this.applyDiscountUseCase.execute({
           orderId: order.id,
-          appliedCouponId: couponId,
+          appliedUserCouponId: couponId,
           discountPrice,
           discountedPrice,
         });

--- a/src/order/application/use-cases/tier-3/prepare-order.use-case.ts
+++ b/src/order/application/use-cases/tier-3/prepare-order.use-case.ts
@@ -72,7 +72,7 @@ export class PrepareOrderUseCase {
         productId: item.productId,
         userId,
         quantity: item.quantity,
-        idempotencyKey,
+        orderId: order.id,
       })),
     });
 

--- a/src/order/application/use-cases/tier-4/place-order.user-case.ts
+++ b/src/order/application/use-cases/tier-4/place-order.user-case.ts
@@ -57,7 +57,7 @@ export class PlaceOrderUseCase {
         order,
         couponId,
         stockReservationIds,
-        idempotencyKey,
+        orderId: order.id,
       });
       throw error;
     }

--- a/src/order/domain/entities/order.entitiy.ts
+++ b/src/order/domain/entities/order.entitiy.ts
@@ -17,7 +17,7 @@ export interface OrderProps {
   status: OrderStatus;
   failedReason: string | null;
   idempotencyKey: string;
-  appliedCouponId: string | null;
+  appliedUserCouponId: string | null;
   createdAt: Date;
   updatedAt: Date;
   OrderItems: OrderItem[];
@@ -31,7 +31,7 @@ export class Order {
       OrderProps,
       | "id"
       | "failedReason"
-      | "appliedCouponId"
+      | "appliedUserCouponId"
       | "createdAt"
       | "updatedAt"
       | "OrderItems"
@@ -42,7 +42,7 @@ export class Order {
       ...props,
       id: uuidv4(),
       failedReason: null,
-      appliedCouponId: null,
+      appliedUserCouponId: null,
       createdAt: now,
       updatedAt: now,
       OrderItems: [],
@@ -70,15 +70,15 @@ export class Order {
   }
 
   applyDiscount({
-    appliedCouponId,
+    appliedUserCouponId,
     discountPrice,
     discountedPrice,
   }: {
-    appliedCouponId: string;
+    appliedUserCouponId: string;
     discountPrice: number;
     discountedPrice: number;
   }): void {
-    this.props.appliedCouponId = appliedCouponId;
+    this.props.appliedUserCouponId = appliedUserCouponId;
     this.props.discountPrice = discountPrice;
     this.props.finalPrice = discountedPrice;
     this.props.updatedAt = new Date();
@@ -112,8 +112,8 @@ export class Order {
     return this.props.idempotencyKey;
   }
 
-  get appliedCouponId(): string | null {
-    return this.props.appliedCouponId;
+  get appliedUserCouponId(): string | null {
+    return this.props.appliedUserCouponId;
   }
 
   get failedReason(): string | null {

--- a/src/order/infrastructure/persistence/factories/order.factory.ts
+++ b/src/order/infrastructure/persistence/factories/order.factory.ts
@@ -27,7 +27,7 @@ export const OrderFactory = createEntityFactory<OrderTypeOrmEntity>(
       failedReason: options.failedReason ?? null,
       idempotencyKey:
         options.idempotencyKey || createTestIdempotencyKey(timestamp, counter),
-      appliedCouponId: options.appliedCouponId ?? null,
+      appliedUserCouponId: options.appliedUserCouponId ?? null,
       orderItems: options.orderItems ?? [],
       ...options,
     });

--- a/src/order/infrastructure/persistence/order.repository.ts
+++ b/src/order/infrastructure/persistence/order.repository.ts
@@ -88,7 +88,7 @@ export class OrderRepository {
       status: entity.status,
       failedReason: entity.failedReason,
       idempotencyKey: entity.idempotencyKey,
-      appliedCouponId: entity.appliedCouponId,
+      appliedUserCouponId: entity.appliedUserCouponId,
       createdAt: entity.createdAt,
       updatedAt: entity.updatedAt,
       OrderItems: orderItems,
@@ -105,7 +105,7 @@ export class OrderRepository {
     entity.status = order.status;
     entity.failedReason = order.failedReason;
     entity.idempotencyKey = order.idempotencyKey;
-    entity.appliedCouponId = order.appliedCouponId;
+    entity.appliedUserCouponId = order.appliedUserCouponId;
     entity.createdAt = order.createdAt;
     entity.updatedAt = order.updatedAt;
     return entity;

--- a/src/order/infrastructure/persistence/orm/order.typeorm.entity.ts
+++ b/src/order/infrastructure/persistence/orm/order.typeorm.entity.ts
@@ -53,10 +53,10 @@ export class OrderTypeOrmEntity {
   @Column({
     type: "varchar",
     length: 255,
-    name: "applied_coupon_id",
+    name: "applied_user_coupon_id",
     nullable: true,
   })
-  appliedCouponId: string | null;
+  appliedUserCouponId: string | null;
 
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;

--- a/src/order/presentation/http/dto/order.dto.ts
+++ b/src/order/presentation/http/dto/order.dto.ts
@@ -211,8 +211,8 @@ export class OrderResponseDto {
       discountAmount: order.discountPrice,
       finalAmount: order.finalPrice,
       status: order.status as OrderStatus,
-      usedCouponId: order.appliedCouponId,
-      usedCouponName: order.appliedCouponId, // For simplicity
+      usedCouponId: order.appliedUserCouponId,
+      usedCouponName: order.appliedUserCouponId, // For simplicity
       idempotencyKey: order.idempotencyKey,
       createdAt: order.createdAt,
       updatedAt: order.updatedAt,

--- a/src/product/application/use-cases/tier-1-in-domain/confirm-stock.use-case.spec.ts
+++ b/src/product/application/use-cases/tier-1-in-domain/confirm-stock.use-case.spec.ts
@@ -56,7 +56,7 @@ describe("ConfirmStockUseCase", () => {
       productId: mockProduct.id,
       userId: uuidv4(),
       quantity: 2,
-      idempotencyKey: uuidv4(),
+      orderId: uuidv4(),
     });
 
     stockReservationRepository.findById.mockResolvedValue(mockStockReservation);
@@ -64,7 +64,7 @@ describe("ConfirmStockUseCase", () => {
 
     const result = await useCase.execute({
       stockReservationId: mockStockReservation.id,
-      idempotencyKey: mockStockReservation.idempotencyKey,
+      orderId: mockStockReservation.orderId,
     });
 
     expect(result.stockReservation.isActive).toBe(false);
@@ -77,7 +77,7 @@ describe("ConfirmStockUseCase", () => {
     await expect(
       useCase.execute({
         stockReservationId: "non-existent",
-        idempotencyKey: uuidv4(),
+        orderId: uuidv4(),
       })
     ).rejects.toThrow(StockReservationNotFoundError);
   });
@@ -87,9 +87,9 @@ describe("ConfirmStockUseCase", () => {
       productId: uuidv4(),
       userId: uuidv4(),
       quantity: 2,
-      idempotencyKey: uuidv4(),
+      orderId: uuidv4(),
     });
-    mockStockReservation.releaseStock(mockStockReservation.idempotencyKey);
+    mockStockReservation.releaseStock(mockStockReservation.orderId);
 
     const mockProduct = Product.create({
       name: "테스트 상품",
@@ -106,7 +106,7 @@ describe("ConfirmStockUseCase", () => {
     await expect(
       useCase.execute({
         stockReservationId: mockStockReservation.id,
-        idempotencyKey: mockStockReservation.idempotencyKey,
+        orderId: mockStockReservation.orderId,
       })
     ).rejects.toThrow(StockReservationNotActiveError);
   });
@@ -117,7 +117,7 @@ describe("ConfirmStockUseCase", () => {
       productId: uuidv4(),
       userId: uuidv4(),
       quantity: 2,
-      idempotencyKey: uuidv4(),
+      orderId: uuidv4(),
       createdAt: new Date(),
       updatedAt: new Date(),
       expiresAt: new Date(Date.now() - 1000),
@@ -142,7 +142,7 @@ describe("ConfirmStockUseCase", () => {
     await expect(
       useCase.execute({
         stockReservationId: mockStockReservation.id,
-        idempotencyKey: mockStockReservation.idempotencyKey,
+        orderId: mockStockReservation.orderId,
       })
     ).rejects.toThrow(StockReservationExpiredError);
   });

--- a/src/product/application/use-cases/tier-1-in-domain/confirm-stock.use-case.ts
+++ b/src/product/application/use-cases/tier-1-in-domain/confirm-stock.use-case.ts
@@ -12,7 +12,7 @@ import { ProductRepository } from "@/product/infrastructure/persistence/product.
 
 export interface ConfirmStockCommand {
   stockReservationId: string;
-  idempotencyKey: string;
+  orderId: string;
 }
 
 @Injectable()
@@ -28,7 +28,7 @@ export class ConfirmStockUseCase {
     stockReservation: StockReservation;
     product: Product;
   }> {
-    const { stockReservationId, idempotencyKey } = command;
+    const { stockReservationId, orderId } = command;
 
     const stockReservation =
       await this.stockReservationRepository.findById(stockReservationId);
@@ -50,7 +50,7 @@ export class ConfirmStockUseCase {
     });
 
     product.confirmStock(stockReservation.quantity);
-    stockReservation.confirmStock(idempotencyKey);
+    stockReservation.confirmStock(orderId);
 
     await this.stockReservationRepository.save(stockReservation);
     await this.productRepository.save(product);

--- a/src/product/application/use-cases/tier-1-in-domain/get-stock-reservations-by-key.use-case.ts
+++ b/src/product/application/use-cases/tier-1-in-domain/get-stock-reservations-by-key.use-case.ts
@@ -4,7 +4,7 @@ import { StockReservationRepository } from "@/product/infrastructure/persistence
 import { Transactional } from "typeorm-transactional";
 
 export interface GetStockReservationsByKeyUseCaseCommand {
-  idempotencyKey: string;
+  orderId: string;
 }
 
 export interface GetStockReservationsByKeyUseCaseResult {
@@ -21,12 +21,10 @@ export class GetStockReservationsByKeyUseCase {
   async execute(
     command: GetStockReservationsByKeyUseCaseCommand
   ): Promise<GetStockReservationsByKeyUseCaseResult> {
-    const { idempotencyKey } = command;
+    const { orderId } = command;
 
     const stockReservations =
-      await this.stockReservationRepository.findByIdempotencyKey(
-        idempotencyKey
-      );
+      await this.stockReservationRepository.findByOrderId(orderId);
 
     return { stockReservations };
   }

--- a/src/product/application/use-cases/tier-1-in-domain/release-stock.use-case.spec.ts
+++ b/src/product/application/use-cases/tier-1-in-domain/release-stock.use-case.spec.ts
@@ -80,7 +80,7 @@ describe("ReleaseStockUseCase", () => {
           productId: mockProduct.id,
           userId: uuidv4(),
           quantity: reservationQuantity,
-          idempotencyKey: uuidv4(),
+          orderId: uuidv4(),
         });
 
         stockReservationRepository.findById.mockResolvedValue(
@@ -90,7 +90,7 @@ describe("ReleaseStockUseCase", () => {
 
         const result = await useCase.execute({
           stockReservationId: "reservation-1",
-          idempotencyKey: mockStockReservation.idempotencyKey,
+          orderId: mockStockReservation.orderId,
         });
 
         expect(mockStockReservation.isActive).toBe(false);
@@ -109,7 +109,7 @@ describe("ReleaseStockUseCase", () => {
     await expect(
       useCase.execute({
         stockReservationId: "non-existent",
-        idempotencyKey: "non-existent",
+        orderId: "non-existent",
       })
     ).rejects.toThrow(StockReservationNotFoundError);
   });
@@ -119,7 +119,7 @@ describe("ReleaseStockUseCase", () => {
       productId: "product-1",
       userId: uuidv4(),
       quantity: 2,
-      idempotencyKey: uuidv4(),
+      orderId: uuidv4(),
     });
 
     const mockProduct = Product.create({
@@ -134,12 +134,12 @@ describe("ReleaseStockUseCase", () => {
     stockReservationRepository.findById.mockResolvedValue(inactiveReservation);
     productRepository.findById.mockResolvedValue(mockProduct);
 
-    inactiveReservation.releaseStock(inactiveReservation.idempotencyKey);
+    inactiveReservation.releaseStock(inactiveReservation.orderId);
 
     await expect(
       useCase.execute({
         stockReservationId: "inactive-reservation",
-        idempotencyKey: "inactive-reservation",
+        orderId: "inactive-reservation",
       })
     ).rejects.toThrow(StockReservationNotActiveError);
   });

--- a/src/product/application/use-cases/tier-1-in-domain/release-stock.use-case.ts
+++ b/src/product/application/use-cases/tier-1-in-domain/release-stock.use-case.ts
@@ -12,7 +12,7 @@ import { ProductRepository } from "@/product/infrastructure/persistence/product.
 
 export interface ReleaseStockCommand {
   stockReservationId: string;
-  idempotencyKey: string;
+  orderId: string;
 }
 
 @Injectable()
@@ -28,7 +28,7 @@ export class ReleaseStockUseCase {
     stockReservation: StockReservation;
     product: Product;
   }> {
-    const { stockReservationId, idempotencyKey } = command;
+    const { stockReservationId, orderId } = command;
 
     const stockReservation =
       await this.stockReservationRepository.findById(stockReservationId);
@@ -50,7 +50,7 @@ export class ReleaseStockUseCase {
     });
 
     product.releaseStock(stockReservation.quantity);
-    stockReservation.releaseStock(idempotencyKey);
+    stockReservation.releaseStock(orderId);
 
     await this.stockReservationRepository.save(stockReservation);
     await this.productRepository.save(product);

--- a/src/product/application/use-cases/tier-1-in-domain/reserve-stock.use-case.spec.ts
+++ b/src/product/application/use-cases/tier-1-in-domain/reserve-stock.use-case.spec.ts
@@ -82,7 +82,7 @@ describe("ReserveStockUseCase", () => {
         productRepository.findById.mockResolvedValue(mockProduct);
 
         const result = await useCase.execute({
-          idempotencyKey: uuidv4(),
+          orderId: uuidv4(),
           productId: mockProduct.id,
           userId,
           quantity: reservationQuantity,
@@ -116,7 +116,7 @@ describe("ReserveStockUseCase", () => {
 
       await expect(
         useCase.execute({
-          idempotencyKey: uuidv4(),
+          orderId: uuidv4(),
           productId: "product-1",
           userId: uuidv4(),
           quantity,
@@ -130,7 +130,7 @@ describe("ReserveStockUseCase", () => {
 
     await expect(
       useCase.execute({
-        idempotencyKey: uuidv4(),
+        orderId: uuidv4(),
         productId: "non-existent",
         userId: uuidv4(),
         quantity: 1,
@@ -152,7 +152,7 @@ describe("ReserveStockUseCase", () => {
 
     await expect(
       useCase.execute({
-        idempotencyKey: uuidv4(),
+        orderId: uuidv4(),
         productId: mockProduct.id,
         userId: uuidv4(),
         quantity: 1,
@@ -174,7 +174,7 @@ describe("ReserveStockUseCase", () => {
 
     await expect(
       useCase.execute({
-        idempotencyKey: uuidv4(),
+        orderId: uuidv4(),
         productId: mockProduct.id,
         userId: uuidv4(),
         quantity: 2,

--- a/src/product/application/use-cases/tier-1-in-domain/reserve-stock.use-case.ts
+++ b/src/product/application/use-cases/tier-1-in-domain/reserve-stock.use-case.ts
@@ -11,7 +11,7 @@ export interface ReserveStockCommand {
   productId: string;
   userId: string;
   quantity: number;
-  idempotencyKey: string;
+  orderId: string;
 }
 
 @Injectable()
@@ -27,7 +27,7 @@ export class ReserveStockUseCase {
     stockReservation: StockReservation;
     product: Product;
   }> {
-    const { productId, userId, quantity, idempotencyKey } = command;
+    const { productId, userId, quantity, orderId } = command;
 
     const product = await this.productRepository.findById(productId);
     if (!product) {
@@ -44,7 +44,7 @@ export class ReserveStockUseCase {
       productId: product.id,
       userId,
       quantity,
-      idempotencyKey,
+      orderId,
     });
 
     await this.stockReservationRepository.save(stockReservation);

--- a/src/product/application/use-cases/tier-2/reserve-stocks.use-case.ts
+++ b/src/product/application/use-cases/tier-2/reserve-stocks.use-case.ts
@@ -9,7 +9,7 @@ export interface ReserveStocksCommand {
     productId: string;
     userId: string;
     quantity: number;
-    idempotencyKey: string;
+    orderId: string;
   }[];
 }
 
@@ -32,7 +32,7 @@ export class ReserveStocksUseCase {
           productId: request.productId,
           userId: request.userId,
           quantity: request.quantity,
-          idempotencyKey: request.idempotencyKey,
+          orderId: request.orderId,
         })
       )
     );

--- a/src/product/domain/entities/stock-reservation.entity.ts
+++ b/src/product/domain/entities/stock-reservation.entity.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 import {
-  StockReservationConfirmStockIdempotencyKeyMismatchError,
-  StockReservationReleaseIdempotencyKeyMismatchError,
+  StockReservationConfirmStockOrderIdMismatchError,
+  StockReservationReleaseOrderIdMismatchError,
 } from "../exceptions/product.exceptions";
 
 export interface StockReservationProps {
@@ -9,7 +9,7 @@ export interface StockReservationProps {
   productId: string;
   userId: string;
   quantity: number;
-  idempotencyKey: string;
+  orderId: string;
   createdAt: Date;
   updatedAt: Date;
   expiresAt: Date;
@@ -37,22 +37,22 @@ export class StockReservation {
     });
   }
 
-  releaseStock(idempotencyKey: string): void {
-    if (this.props.idempotencyKey !== idempotencyKey) {
-      throw new StockReservationReleaseIdempotencyKeyMismatchError(
+  releaseStock(orderId: string): void {
+    if (this.props.orderId !== orderId) {
+      throw new StockReservationReleaseOrderIdMismatchError(
         this.props.id,
-        idempotencyKey
+        orderId
       );
     }
     this.props.isActive = false;
     this.props.updatedAt = new Date();
   }
 
-  confirmStock(idempotencyKey: string): void {
-    if (this.props.idempotencyKey !== idempotencyKey) {
-      throw new StockReservationConfirmStockIdempotencyKeyMismatchError(
+  confirmStock(orderId: string): void {
+    if (this.props.orderId !== orderId) {
+      throw new StockReservationConfirmStockOrderIdMismatchError(
         this.props.id,
-        idempotencyKey
+        orderId
       );
     }
     this.props.isActive = false;
@@ -75,8 +75,8 @@ export class StockReservation {
     return this.props.quantity;
   }
 
-  get idempotencyKey(): string {
-    return this.props.idempotencyKey;
+  get orderId(): string {
+    return this.props.orderId;
   }
 
   get createdAt(): Date {

--- a/src/product/domain/exceptions/product.exceptions.ts
+++ b/src/product/domain/exceptions/product.exceptions.ts
@@ -69,22 +69,22 @@ export class StockReservationExpiredError extends ProductDomainError {
   }
 }
 
-export class StockReservationReleaseIdempotencyKeyMismatchError extends ProductDomainError {
+export class StockReservationReleaseOrderIdMismatchError extends ProductDomainError {
   readonly code = "STOCK_RESERVATION_RELEASE_IDEMPOTENCY_KEY_MISMATCH";
 
-  constructor(stockReservationId: string, idempotencyKey: string) {
+  constructor(stockReservationId: string, orderId: string) {
     super(
-      `재고 예약 취소를 위한 멱등성 키가 일치하지 않습니다. ID: ${stockReservationId}, 키: ${idempotencyKey}`
+      `재고 예약 취소를 위한 주문 ID가 일치하지 않습니다. ID: ${stockReservationId}, 주문 ID: ${orderId}`
     );
   }
 }
 
-export class StockReservationConfirmStockIdempotencyKeyMismatchError extends ProductDomainError {
+export class StockReservationConfirmStockOrderIdMismatchError extends ProductDomainError {
   readonly code = "STOCK_RESERVATION_CONFIRM_STOCK_IDEMPOTENCY_KEY_MISMATCH";
 
-  constructor(stockReservationId: string, idempotencyKey: string) {
+  constructor(stockReservationId: string, orderId: string) {
     super(
-      `재고 예약 확정을 위한 멱등성 키가 일치하지 않습니다. ID: ${stockReservationId}, 키: ${idempotencyKey}`
+      `재고 예약 확정을 위한 주문 ID가 일치하지 않습니다. ID: ${stockReservationId}, 주문 ID: ${orderId}`
     );
   }
 }

--- a/src/product/infrastructure/persistence/orm/stock-reservations.typeorm.entity.ts
+++ b/src/product/infrastructure/persistence/orm/stock-reservations.typeorm.entity.ts
@@ -28,8 +28,8 @@ export class StockReservationTypeOrmEntity {
   @Column({ type: "boolean", name: "is_active", default: true })
   isActive: boolean;
 
-  @Column({ type: "varchar", length: 255, name: "idempotency_key" })
-  idempotencyKey: string;
+  @Column({ type: "varchar", length: 255, name: "order_id" })
+  orderId: string;
 
   @Column({ type: "timestamp", name: "expires_at" })
   expiresAt: Date;

--- a/src/product/infrastructure/persistence/stock-reservations.repository.ts
+++ b/src/product/infrastructure/persistence/stock-reservations.repository.ts
@@ -24,11 +24,9 @@ export class StockReservationRepository {
     return entity ? this.toDomain(entity) : null;
   }
 
-  async findByIdempotencyKey(
-    idempotencyKey: string
-  ): Promise<StockReservation[]> {
+  async findByOrderId(orderId: string): Promise<StockReservation[]> {
     const entities = await this.stockReservationRepository.find({
-      where: { idempotencyKey },
+      where: { orderId },
     });
     return entities.map((entity) => this.toDomain(entity));
   }
@@ -41,7 +39,7 @@ export class StockReservationRepository {
     entity.productId = stockReservation.productId;
     entity.userId = stockReservation.userId;
     entity.quantity = stockReservation.quantity;
-    entity.idempotencyKey = stockReservation.idempotencyKey;
+    entity.orderId = stockReservation.orderId;
     entity.createdAt = stockReservation.createdAt;
     entity.updatedAt = stockReservation.updatedAt;
     entity.expiresAt = stockReservation.expiresAt;
@@ -55,7 +53,7 @@ export class StockReservationRepository {
       productId: entity.productId,
       userId: entity.userId,
       quantity: entity.quantity,
-      idempotencyKey: entity.idempotencyKey,
+      orderId: entity.orderId,
       createdAt: entity.createdAt,
       updatedAt: entity.updatedAt,
       expiresAt: entity.expiresAt,

--- a/src/wallet/application/use-cases/tier-1-in-domain/charge-points.use-case.spec.ts
+++ b/src/wallet/application/use-cases/tier-1-in-domain/charge-points.use-case.spec.ts
@@ -69,6 +69,7 @@ describe("ChargePointsUseCase", () => {
           userId: mockUserId,
           amount: chargeAmount,
           idempotencyKey: uuidv4(),
+          refId: null,
         });
 
         // then
@@ -90,6 +91,7 @@ describe("ChargePointsUseCase", () => {
         userId: mockUserId,
         amount: 10000,
         idempotencyKey: uuidv4(),
+        refId: null,
       })
     ).rejects.toThrow(UserBalanceNotFoundError);
   });
@@ -121,6 +123,7 @@ describe("ChargePointsUseCase", () => {
             userId: mockUserId,
             amount: chargeAmount,
             idempotencyKey: uuidv4(),
+            refId: null,
           })
         ).rejects.toThrow(InvalidChargeAmountError);
       });

--- a/src/wallet/application/use-cases/tier-1-in-domain/charge-points.use-case.ts
+++ b/src/wallet/application/use-cases/tier-1-in-domain/charge-points.use-case.ts
@@ -9,6 +9,7 @@ export interface ChargePointsUseCaseCommand {
   userId: string;
   amount: number;
   idempotencyKey: string;
+  refId: string | null;
 }
 
 export interface ChargePointsUseCaseResult {
@@ -26,7 +27,7 @@ export class ChargePointsUseCase {
   async execute(
     command: ChargePointsUseCaseCommand
   ): Promise<ChargePointsUseCaseResult> {
-    const { userId, amount, idempotencyKey } = command;
+    const { userId, amount, idempotencyKey, refId } = command;
 
     const userBalance = await this.userBalanceRepository.findByUserId(userId);
 
@@ -40,6 +41,7 @@ export class ChargePointsUseCase {
       amount,
       type: "CHARGE",
       idempotencyKey,
+      refId,
     });
 
     await Promise.all([

--- a/src/wallet/application/use-cases/tier-1-in-domain/recover-points.use-case.spec.ts
+++ b/src/wallet/application/use-cases/tier-1-in-domain/recover-points.use-case.spec.ts
@@ -70,12 +70,13 @@ describe("RecoverPointsUseCase", () => {
         });
 
         userBalanceRepository.findByUserId.mockResolvedValue(existingBalance);
-        pointTransactionRepository.findByOrderIdempotencyKey.mockResolvedValue([
+        pointTransactionRepository.findByRefId.mockResolvedValue([
           PointTransaction.create({
             userId: mockUserId,
             amount: recoverAmount,
             type: "USE",
-            idempotencyKey: "test-idempotency-key",
+            idempotencyKey: null,
+            refId: "test-order-id",
           }),
         ]);
 
@@ -83,7 +84,7 @@ describe("RecoverPointsUseCase", () => {
         const result = await useCase.execute({
           userId: mockUserId,
           amount: recoverAmount,
-          idempotencyKey: "test-idempotency-key",
+          refId: "test-order-id",
         });
 
         // then
@@ -104,7 +105,7 @@ describe("RecoverPointsUseCase", () => {
       useCase.execute({
         userId: mockUserId,
         amount: 10000,
-        idempotencyKey: uuidv4(),
+        refId: "test-order-id",
       })
     ).rejects.toThrow(UserBalanceNotFoundError);
   });
@@ -117,14 +118,14 @@ describe("RecoverPointsUseCase", () => {
         balance: 10000,
       })
     );
-    pointTransactionRepository.findByOrderIdempotencyKey.mockResolvedValue([]);
+    pointTransactionRepository.findByRefId.mockResolvedValue([]);
 
     // when & then
     await expect(
       useCase.execute({
         userId: mockUserId,
         amount: 10000,
-        idempotencyKey: uuidv4(),
+        refId: "test-order-id",
       })
     ).rejects.toThrow(PointTransactionNotFoundError);
   });
@@ -137,18 +138,20 @@ describe("RecoverPointsUseCase", () => {
         balance: 10000,
       })
     );
-    pointTransactionRepository.findByOrderIdempotencyKey.mockResolvedValue([
+    pointTransactionRepository.findByRefId.mockResolvedValue([
       PointTransaction.create({
         userId: mockUserId,
         amount: 10000,
         type: "USE",
-        idempotencyKey: "test-idempotency-key",
+        idempotencyKey: null,
+        refId: "test-order-id",
       }),
       PointTransaction.create({
         userId: mockUserId,
         amount: 10000,
         type: "RECOVER",
-        idempotencyKey: "test-idempotency-key",
+        idempotencyKey: null,
+        refId: "test-order-id",
       }),
     ]);
 
@@ -157,7 +160,7 @@ describe("RecoverPointsUseCase", () => {
       useCase.execute({
         userId: mockUserId,
         amount: 10000,
-        idempotencyKey: "test-idempotency-key",
+        refId: "test-order-id",
       })
     ).rejects.toThrow(PointTransactionAlreadyRecoveredError);
   });

--- a/src/wallet/application/use-cases/tier-1-in-domain/recover-points.use-case.ts
+++ b/src/wallet/application/use-cases/tier-1-in-domain/recover-points.use-case.ts
@@ -9,7 +9,7 @@ import { ValidatePointTransactionService } from "@/wallet/domain/services/valida
 export interface RecoverPointsUseCaseCommand {
   userId: string;
   amount: number;
-  idempotencyKey: string;
+  refId: string;
 }
 
 export interface RecoverPointsUseCaseResult {
@@ -28,7 +28,7 @@ export class RecoverPointsUseCase {
   async execute(
     command: RecoverPointsUseCaseCommand
   ): Promise<RecoverPointsUseCaseResult> {
-    const { userId, amount, idempotencyKey } = command;
+    const { userId, amount, refId } = command;
 
     const userBalance = await this.userBalanceRepository.findByUserId(userId);
 
@@ -37,13 +37,10 @@ export class RecoverPointsUseCase {
     }
 
     const existingPointTransaction =
-      await this.pointTransactionRepository.findByOrderIdempotencyKey(
-        userId,
-        idempotencyKey
-      );
+      await this.pointTransactionRepository.findByRefId(userId, refId);
 
     this.validatePointTransactionService.validatePointRecovery({
-      idempotencyKey,
+      refId,
       existingPointTransaction,
     });
 
@@ -52,7 +49,8 @@ export class RecoverPointsUseCase {
       userId,
       amount,
       type: "RECOVER",
-      idempotencyKey,
+      idempotencyKey: null,
+      refId,
     });
 
     await Promise.all([

--- a/src/wallet/application/use-cases/tier-1-in-domain/use-points.use-case.spec.ts
+++ b/src/wallet/application/use-cases/tier-1-in-domain/use-points.use-case.spec.ts
@@ -75,6 +75,7 @@ describe("UsePointsUseCase", () => {
           userId: mockUserId,
           amount: useAmount,
           idempotencyKey: uuidv4(),
+          refId: null,
         });
 
         // then
@@ -112,6 +113,7 @@ describe("UsePointsUseCase", () => {
             userId: mockUserId,
             amount: useAmount,
             idempotencyKey: uuidv4(),
+            refId: null,
           })
         ).rejects.toThrow(InsufficientPointBalanceError);
       });
@@ -128,6 +130,7 @@ describe("UsePointsUseCase", () => {
         userId: mockUserId,
         amount: 10000,
         idempotencyKey: uuidv4(),
+        refId: null,
       })
     ).rejects.toThrow(UserBalanceNotFoundError);
   });

--- a/src/wallet/application/use-cases/tier-1-in-domain/use-points.use-case.ts
+++ b/src/wallet/application/use-cases/tier-1-in-domain/use-points.use-case.ts
@@ -9,6 +9,7 @@ import { ValidatePointTransactionService } from "@/wallet/domain/services/valida
 export interface UsePointsUseCaseCommand {
   userId: string;
   amount: number;
+  refId: string;
   idempotencyKey: string;
 }
 
@@ -28,7 +29,7 @@ export class UsePointsUseCase {
   async execute(
     command: UsePointsUseCaseCommand
   ): Promise<UsePointsUseCaseResult> {
-    const { userId, amount, idempotencyKey } = command;
+    const { userId, amount, refId, idempotencyKey } = command;
 
     const userBalance = await this.userBalanceRepository.findByUserId(userId);
 
@@ -47,6 +48,7 @@ export class UsePointsUseCase {
       amount,
       type: "USE",
       idempotencyKey,
+      refId,
     });
 
     await Promise.all([

--- a/src/wallet/domain/entities/point-transaction.entity.ts
+++ b/src/wallet/domain/entities/point-transaction.entity.ts
@@ -5,7 +5,8 @@ export interface PointTransactionProps {
   userId: string;
   amount: number;
   type: "CHARGE" | "USE" | "RECOVER";
-  idempotencyKey: string;
+  idempotencyKey: string | null;
+  refId: string | null;
   createdAt: Date;
 }
 
@@ -40,6 +41,10 @@ export class PointTransaction {
 
   get idempotencyKey(): string {
     return this.props.idempotencyKey;
+  }
+
+  get refId(): string {
+    return this.props.refId;
   }
 
   get createdAt(): Date {

--- a/src/wallet/domain/services/validate-point-transaction.service.ts
+++ b/src/wallet/domain/services/validate-point-transaction.service.ts
@@ -8,25 +8,25 @@ import {
 
 export class ValidatePointTransactionService {
   validatePointRecovery({
-    idempotencyKey,
+    refId,
     existingPointTransaction,
   }: {
-    idempotencyKey: string;
+    refId: string;
     existingPointTransaction: PointTransaction[];
   }): void {
     const correctTransactionExists = existingPointTransaction.some(
-      (pt) => pt.type === "USE" && pt.idempotencyKey === idempotencyKey
+      (pt) => pt.type === "USE" && pt.refId === refId
     );
     const isAlreadyRecovered = existingPointTransaction.some(
-      (pt) => pt.type === "RECOVER" && pt.idempotencyKey === idempotencyKey
+      (pt) => pt.type === "RECOVER" && pt.refId === refId
     );
 
     if (!correctTransactionExists) {
-      throw new PointTransactionNotFoundError(idempotencyKey);
+      throw new PointTransactionNotFoundError(refId);
     }
 
     if (isAlreadyRecovered) {
-      throw new PointTransactionAlreadyRecoveredError(idempotencyKey);
+      throw new PointTransactionAlreadyRecoveredError(refId);
     }
   }
 

--- a/src/wallet/infrastructure/persistence/orm/point-transaction.typeorm.entity.ts
+++ b/src/wallet/infrastructure/persistence/orm/point-transaction.typeorm.entity.ts
@@ -31,8 +31,11 @@ export class PointTransactionTypeOrmEntity {
   @Column({ type: "enum", name: "type", enum: PointTransactionType })
   type: PointTransactionType;
 
-  @Column({ type: "varchar", name: "idempotency_key" })
-  idempotencyKey: string;
+  @Column({ type: "varchar", name: "idempotency_key", nullable: true })
+  idempotencyKey: string | null;
+
+  @Column({ type: "varchar", name: "ref_id", nullable: true })
+  refId: string | null;
 
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;

--- a/src/wallet/infrastructure/persistence/point-transaction.repository.ts
+++ b/src/wallet/infrastructure/persistence/point-transaction.repository.ts
@@ -21,12 +21,12 @@ export class PointTransactionRepository {
     return entities.map((entity) => this.toDomain(entity));
   }
 
-  async findByOrderIdempotencyKey(
+  async findByRefId(
     userId: string,
-    idempotencyKey: string
+    refId: string
   ): Promise<PointTransaction[]> {
     const entities = await this.pointTransactionRepository.find({
-      where: { userId, idempotencyKey: idempotencyKey },
+      where: { userId, refId: refId },
     });
     return entities.map((entity) => this.toDomain(entity));
   }
@@ -44,6 +44,7 @@ export class PointTransactionRepository {
       amount: entity.amount,
       type: entity.type,
       idempotencyKey: entity.idempotencyKey,
+      refId: entity.refId,
       createdAt: entity.createdAt,
     });
   }
@@ -56,7 +57,7 @@ export class PointTransactionRepository {
     entity.userId = pointTransaction.userId;
     entity.amount = pointTransaction.amount;
     entity.type = pointTransaction.type as PointTransactionType;
-    entity.idempotencyKey = pointTransaction.idempotencyKey;
+    entity.refId = pointTransaction.refId;
     entity.createdAt = pointTransaction.createdAt;
     return entity;
   }

--- a/src/wallet/presentation/http/wallet.controller.ts
+++ b/src/wallet/presentation/http/wallet.controller.ts
@@ -76,6 +76,7 @@ export class WalletController {
       userId: user.id,
       amount: chargeDto.amount,
       idempotencyKey: chargeDto.idempotencyKey ?? uuidv4(),
+      refId: null,
     });
     return ApiResponseDto.success(
       ChargeResponseDto.fromEntity(result.userBalance, result.pointTransaction),


### PR DESCRIPTION
### 💬 배경

- 멱등성키는 멱등성 검증에만 사용하도록 개편, 기존에는 idempotencyKey로 복구등을 해서 의미가 혼잡했었음.
- refId, orderId등을 사용하여 의미론적으로 이해가 쉽도록 개편
