### PR TITLE
fix: typeorm 필드 수정 (varchar, uuid 등)

### DIFF
--- a/docs/06-erd.md
+++ b/docs/06-erd.md
@@ -15,9 +15,9 @@ erDiagram
 
     products {
         uuid id PK
-        varchar name
+        varchar name UK
         text description
-        bigint price
+        int price
         integer total_stock
         integer reserved_stock
         boolean is_active
@@ -27,78 +27,92 @@ erDiagram
 
     orders {
         uuid id PK
-        uuid user_id FK
-        bigint total_amount
-        bigint discount_amount
-        bigint final_amount
+        varchar user_id FK
+        int total_price
+        int discount_price
+        int final_price
         enum status
-        varchar request_id UK
-        uuid used_coupon_id FK
+        text failed_reason
+        varchar idempotency_key UK
+        varchar applied_coupon_id FK
         timestamp created_at
         timestamp updated_at
     }
 
     order_items {
         uuid id PK
-        uuid order_id FK
-        uuid product_id FK
-        integer quantity
-        bigint unit_price
-        bigint total_price
+        varchar order_id FK
+        varchar product_id FK
+        int quantity
+        int unit_price
+        int total_price
         timestamp created_at
+        timestamp updated_at
     }
 
     coupons {
         uuid id PK
-        varchar code UK
         varchar name
-        enum type
-        bigint discount_value
-        bigint max_discount
-        bigint min_order_amount
-        integer total_quantity
-        integer used_quantity
-        timestamp valid_from
-        timestamp valid_to
-        boolean is_active
+        text description
+        varchar coupon_code UK
+        varchar discount_type
+        int discount_value
+        int minimum_order_price
+        int max_discount_price
+        int issued_count
+        int used_count
+        int total_count
+        timestamp start_date
+        timestamp end_date
+        int expires_in_days
         timestamp created_at
         timestamp updated_at
     }
 
     user_coupons {
         uuid id PK
-        uuid user_id FK
-        uuid coupon_id FK
+        varchar coupon_id FK
+        varchar user_id FK
+        varchar order_id FK
+        int discount_price
         enum status
-        timestamp issued_at
+        varchar issued_idempotency_key
+        varchar used_idempotency_key
+        timestamp expires_at
         timestamp used_at
+        timestamp cancelled_at
+        timestamp created_at
+        timestamp updated_at
     }
 
     user_balances {
         uuid id PK
-        uuid user_id FK
-        bigint balance
+        varchar user_id FK
+        int balance
+        timestamp created_at
         timestamp updated_at
     }
 
     point_transactions {
         uuid id PK
-        uuid user_id FK
+        varchar user_id FK
+        int amount
         enum type
-        bigint amount
-        bigint balance_after
-        varchar reason
-        varchar reference_id
+        varchar idempotency_key
         timestamp created_at
+        timestamp updated_at
     }
 
     stock_reservations {
-        varchar reservation_id PK
-        uuid product_id FK
-        uuid user_id FK
-        integer quantity
-        timestamp created_at
+        uuid id PK
+        varchar product_id FK
+        varchar user_id FK
+        int quantity
+        boolean is_active
+        varchar idempotency_key
         timestamp expires_at
+        timestamp created_at
+        timestamp updated_at
     }
 
     %% 관계 정의
@@ -137,9 +151,9 @@ erDiagram
 | 컬럼           | 타입         | 제약조건                  | 설명                |
 | -------------- | ------------ | ------------------------- | ------------------- |
 | id             | UUID         | PRIMARY KEY               | 상품 ID             |
-| name           | VARCHAR(255) | NOT NULL                  | 상품명              |
-| description    | TEXT         |                           | 상품 설명           |
-| price          | BIGINT       | NOT NULL                  | 상품 가격 (원 단위) |
+| name           | VARCHAR(255) | UNIQUE, NOT NULL          | 상품명              |
+| description    | TEXT         | NOT NULL                  | 상품 설명           |
+| price          | INT          | NOT NULL                  | 상품 가격 (원 단위) |
 | total_stock    | INTEGER      | NOT NULL, DEFAULT 0       | 총 재고 수량        |
 | reserved_stock | INTEGER      | DEFAULT 0                 | 예약된 재고 수량    |
 | is_active      | BOOLEAN      | NOT NULL, DEFAULT TRUE    | 활성화 상태         |
@@ -148,90 +162,104 @@ erDiagram
 
 ### 3. orders (주문)
 
-| 컬럼            | 타입         | 제약조건                  | 설명                                           |
-| --------------- | ------------ | ------------------------- | ---------------------------------------------- |
-| id              | UUID         | PRIMARY KEY               | 주문 ID                                        |
-| user_id         | UUID         | NOT NULL, FOREIGN KEY     | 사용자 ID                                      |
-| total_amount    | BIGINT       | NOT NULL                  | 총 주문 금액                                   |
-| discount_amount | BIGINT       | DEFAULT 0                 | 할인 금액                                      |
-| final_amount    | BIGINT       | NOT NULL                  | 최종 결제 금액                                 |
-| status          | ENUM         | NOT NULL                  | 주문 상태 (PENDING, SUCCESS, FAILED, CANCELED) |
-| request_id      | VARCHAR(255) | UNIQUE, NOT NULL          | 중복 요청 방지 ID                              |
-| used_coupon_id  | UUID         | FOREIGN KEY               | 사용된 쿠폰 ID                                 |
-| created_at      | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 생성일시                                       |
-| updated_at      | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 수정일시                                       |
+| 컬럼              | 타입         | 제약조건                  | 설명                                            |
+| ----------------- | ------------ | ------------------------- | ----------------------------------------------- |
+| id                | UUID         | PRIMARY KEY               | 주문 ID                                         |
+| user_id           | VARCHAR(255) | NOT NULL, FOREIGN KEY     | 사용자 ID                                       |
+| total_price       | INT          | NOT NULL                  | 총 주문 금액                                    |
+| discount_price    | INT          | DEFAULT 0                 | 할인 금액                                       |
+| final_price       | INT          | NOT NULL                  | 최종 결제 금액                                  |
+| status            | ENUM         | NOT NULL                  | 주문 상태 (PENDING, SUCCESS, FAILED, CANCELLED) |
+| failed_reason     | TEXT         | NULLABLE                  | 실패 사유                                       |
+| idempotency_key   | VARCHAR(255) | UNIQUE, NOT NULL          | 중복 요청 방지 ID                               |
+| applied_coupon_id | VARCHAR(255) | FOREIGN KEY, NULLABLE     | 적용된 쿠폰 ID                                  |
+| created_at        | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 생성일시                                        |
+| updated_at        | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 수정일시                                        |
 
 ### 4. order_items (주문 항목)
 
-| 컬럼        | 타입      | 제약조건                  | 설명         |
-| ----------- | --------- | ------------------------- | ------------ |
-| id          | UUID      | PRIMARY KEY               | 주문 항목 ID |
-| order_id    | UUID      | NOT NULL, FOREIGN KEY     | 주문 ID      |
-| product_id  | UUID      | NOT NULL, FOREIGN KEY     | 상품 ID      |
-| quantity    | INTEGER   | NOT NULL                  | 주문 수량    |
-| unit_price  | BIGINT    | NOT NULL                  | 단가         |
-| total_price | BIGINT    | NOT NULL                  | 항목 총 가격 |
-| created_at  | TIMESTAMP | DEFAULT CURRENT_TIMESTAMP | 생성일시     |
+| 컬럼        | 타입         | 제약조건                  | 설명         |
+| ----------- | ------------ | ------------------------- | ------------ |
+| id          | UUID         | PRIMARY KEY               | 주문 항목 ID |
+| order_id    | VARCHAR(255) | NOT NULL, FOREIGN KEY     | 주문 ID      |
+| product_id  | VARCHAR(255) | NOT NULL, FOREIGN KEY     | 상품 ID      |
+| quantity    | INT          | NOT NULL                  | 주문 수량    |
+| unit_price  | INT          | NOT NULL                  | 단가         |
+| total_price | INT          | NOT NULL                  | 항목 총 가격 |
+| created_at  | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 생성일시     |
+| updated_at  | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 수정일시     |
 
 ### 5. coupons (쿠폰)
 
-| 컬럼             | 타입         | 제약조건                  | 설명                                 |
-| ---------------- | ------------ | ------------------------- | ------------------------------------ |
-| id               | UUID         | PRIMARY KEY               | 쿠폰 ID                              |
-| code             | VARCHAR(50)  | UNIQUE, NOT NULL          | 쿠폰 코드                            |
-| name             | VARCHAR(255) | NOT NULL                  | 쿠폰명                               |
-| type             | ENUM         | NOT NULL                  | 할인 타입 (PERCENTAGE, FIXED_AMOUNT) |
-| discount_value   | BIGINT       | NOT NULL                  | 할인값 (% 또는 고정금액)             |
-| max_discount     | BIGINT       |                           | 최대 할인 금액                       |
-| min_order_amount | BIGINT       | DEFAULT 0                 | 최소 주문 금액                       |
-| total_quantity   | INTEGER      | NOT NULL                  | 총 발급 수량                         |
-| used_quantity    | INTEGER      | DEFAULT 0                 | 사용된 수량                          |
-| valid_from       | TIMESTAMP    | NOT NULL                  | 유효 시작일                          |
-| valid_to         | TIMESTAMP    | NOT NULL                  | 유효 종료일                          |
-| is_active        | BOOLEAN      | NOT NULL, DEFAULT TRUE    | 활성화 상태                          |
-| created_at       | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 생성일시                             |
-| updated_at       | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 수정일시                             |
+| 컬럼                | 타입         | 제약조건                  | 설명                          |
+| ------------------- | ------------ | ------------------------- | ----------------------------- |
+| id                  | UUID         | PRIMARY KEY               | 쿠폰 ID                       |
+| name                | VARCHAR(255) | NOT NULL                  | 쿠폰명                        |
+| description         | TEXT         | NOT NULL                  | 쿠폰 설명                     |
+| coupon_code         | VARCHAR(100) | UNIQUE, NOT NULL          | 쿠폰 코드                     |
+| discount_type       | VARCHAR(20)  | NOT NULL                  | 할인 타입 (FIXED, PERCENTAGE) |
+| discount_value      | INT          | NOT NULL                  | 할인값 (% 또는 고정금액)      |
+| minimum_order_price | INT          | NOT NULL                  | 최소 주문 금액                |
+| max_discount_price  | INT          | NULLABLE                  | 최대 할인 금액                |
+| issued_count        | INT          | DEFAULT 0                 | 발급된 수량                   |
+| used_count          | INT          | DEFAULT 0                 | 사용된 수량                   |
+| total_count         | INT          | NOT NULL                  | 총 발급 가능 수량             |
+| start_date          | TIMESTAMP    | NOT NULL                  | 유효 시작일                   |
+| end_date            | TIMESTAMP    | NOT NULL                  | 유효 종료일                   |
+| expires_in_days     | INT          | NOT NULL                  | 발급 후 만료일 (일 단위)      |
+| created_at          | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 생성일시                      |
+| updated_at          | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 수정일시                      |
 
 ### 6. user_coupons (사용자 쿠폰)
 
-| 컬럼      | 타입      | 제약조건                  | 설명                                   |
-| --------- | --------- | ------------------------- | -------------------------------------- |
-| id        | UUID      | PRIMARY KEY               | 사용자 쿠폰 ID                         |
-| user_id   | UUID      | NOT NULL, FOREIGN KEY     | 사용자 ID                              |
-| coupon_id | UUID      | NOT NULL, FOREIGN KEY     | 쿠폰 ID                                |
-| status    | ENUM      | NOT NULL                  | 상태 (ACTIVE, USED, EXPIRED, CANCELED) |
-| issued_at | TIMESTAMP | DEFAULT CURRENT_TIMESTAMP | 발급일시                               |
-| used_at   | TIMESTAMP |                           | 사용일시                               |
+| 컬럼                   | 타입         | 제약조건                  | 설명                           |
+| ---------------------- | ------------ | ------------------------- | ------------------------------ |
+| id                     | UUID         | PRIMARY KEY               | 사용자 쿠폰 ID                 |
+| coupon_id              | VARCHAR(255) | NOT NULL, FOREIGN KEY     | 쿠폰 ID                        |
+| user_id                | VARCHAR(255) | NOT NULL, FOREIGN KEY     | 사용자 ID                      |
+| order_id               | VARCHAR(255) | FOREIGN KEY, NULLABLE     | 사용된 주문 ID                 |
+| discount_price         | INT          | NULLABLE                  | 실제 할인된 금액               |
+| status                 | ENUM         | NOT NULL                  | 상태 (ISSUED, USED, CANCELLED) |
+| issued_idempotency_key | VARCHAR(255) | NULLABLE                  | 발급 중복 방지 키              |
+| used_idempotency_key   | VARCHAR(255) | NULLABLE                  | 사용 중복 방지 키              |
+| expires_at             | TIMESTAMP    | NOT NULL                  | 만료일시                       |
+| used_at                | TIMESTAMP    | NULLABLE                  | 사용일시                       |
+| cancelled_at           | TIMESTAMP    | NULLABLE                  | 취소일시                       |
+| created_at             | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 발급일시                       |
+| updated_at             | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 수정일시                       |
 
 ### 7. user_balances (사용자 잔액)
 
-| 컬럼       | 타입      | 제약조건                  | 설명             |
-| ---------- | --------- | ------------------------- | ---------------- |
-| id         | UUID      | PRIMARY KEY               | 잔액 ID          |
-| user_id    | UUID      | UNIQUE, NOT NULL, FK      | 사용자 ID        |
-| balance    | BIGINT    | NOT NULL, DEFAULT 0       | 사용 가능한 잔액 |
-| updated_at | TIMESTAMP | DEFAULT CURRENT_TIMESTAMP | 수정일시         |
+| 컬럼       | 타입         | 제약조건                  | 설명             |
+| ---------- | ------------ | ------------------------- | ---------------- |
+| id         | UUID         | PRIMARY KEY               | 잔액 ID          |
+| user_id    | VARCHAR(255) | NOT NULL, FOREIGN KEY     | 사용자 ID        |
+| balance    | INT          | NOT NULL, DEFAULT 0       | 사용 가능한 잔액 |
+| created_at | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 생성일시         |
+| updated_at | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 수정일시         |
 
 ### 8. point_transactions (포인트 거래)
 
-| 컬럼          | 타입         | 제약조건                  | 설명                               |
-| ------------- | ------------ | ------------------------- | ---------------------------------- |
-| id            | UUID         | PRIMARY KEY               | 거래 ID                            |
-| user_id       | UUID         | NOT NULL, FOREIGN KEY     | 사용자 ID                          |
-| type          | ENUM         | NOT NULL                  | 거래 타입 (CHARGE, DEDUCT, REFUND) |
-| amount        | BIGINT       | NOT NULL                  | 거래 금액                          |
-| balance_after | BIGINT       | NOT NULL                  | 거래 후 잔액                       |
-| reason        | VARCHAR(255) |                           | 거래 사유                          |
-| reference_id  | VARCHAR(255) |                           | 참조 ID (주문 ID 등)               |
-| created_at    | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 생성일시                           |
+| 컬럼            | 타입         | 제약조건                  | 설명                             |
+| --------------- | ------------ | ------------------------- | -------------------------------- |
+| id              | UUID         | PRIMARY KEY               | 거래 ID                          |
+| user_id         | VARCHAR(255) | NOT NULL, FOREIGN KEY     | 사용자 ID                        |
+| amount          | INT          | NOT NULL                  | 거래 금액                        |
+| type            | ENUM         | NOT NULL                  | 거래 타입 (CHARGE, USE, RECOVER) |
+| idempotency_key | VARCHAR(255) | NOT NULL                  | 중복 방지 키                     |
+| created_at      | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 생성일시                         |
+| updated_at      | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 수정일시                         |
 
 ### 9. stock_reservations (재고 예약)
 
-| 컬럼           | 타입         | 제약조건                  | 설명                        |
-| -------------- | ------------ | ------------------------- | --------------------------- |
-| reservation_id | VARCHAR(255) | PRIMARY KEY               | 예약 ID (UUID 또는 복합키)  |
-| product_id     | UUID         | NOT NULL, FOREIGN KEY     | 상품 ID                     |
-| user_id        | UUID         | NOT NULL, FOREIGN KEY     | 사용자 ID                   |
-| quantity       | INTEGER      | NOT NULL                  | 예약 수량                   |
-| created_at     | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 예약 생성일시               |
-| expires_at     | TIMESTAMP    | NOT NULL                  | 예약 만료일시 (생성 + 30초) |
+| 컬럼            | 타입         | 제약조건                  | 설명                        |
+| --------------- | ------------ | ------------------------- | --------------------------- |
+| id              | UUID         | PRIMARY KEY               | 예약 ID                     |
+| product_id      | VARCHAR(255) | NOT NULL, FOREIGN KEY     | 상품 ID                     |
+| user_id         | VARCHAR(255) | NOT NULL, FOREIGN KEY     | 사용자 ID                   |
+| quantity        | INT          | NOT NULL                  | 예약 수량                   |
+| is_active       | BOOLEAN      | NOT NULL, DEFAULT TRUE    | 활성화 상태                 |
+| idempotency_key | VARCHAR(255) | NOT NULL                  | 중복 방지 키                |
+| expires_at      | TIMESTAMP    | NOT NULL                  | 예약 만료일시 (생성 + 30초) |
+| created_at      | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 예약 생성일시               |
+| updated_at      | TIMESTAMP    | DEFAULT CURRENT_TIMESTAMP | 수정일시                    |

--- a/src/coupon/infrastructure/persistence/orm/coupon.typeorm.entity.ts
+++ b/src/coupon/infrastructure/persistence/orm/coupon.typeorm.entity.ts
@@ -14,7 +14,7 @@ export class CouponTypeOrmEntity {
   @PrimaryGeneratedColumn("uuid")
   id: string;
 
-  @Column({ type: "varchar", length: 255 })
+  @Column({ type: "varchar", length: 100 })
   name: string;
 
   @Column({ type: "text" })

--- a/src/coupon/infrastructure/persistence/orm/user-coupon.typeorm.entity.ts
+++ b/src/coupon/infrastructure/persistence/orm/user-coupon.typeorm.entity.ts
@@ -24,15 +24,15 @@ export class UserCouponTypeOrmEntity {
   @PrimaryGeneratedColumn("uuid")
   id: string;
 
-  @Column({ type: "varchar", name: "coupon_id", length: 255 })
+  @Column({ type: "uuid", name: "coupon_id" })
   @Index("idx_user_coupons_coupon_id")
   couponId: string;
 
-  @Column({ type: "varchar", name: "user_id", length: 255 })
+  @Column({ type: "uuid", name: "user_id" })
   @Index("idx_user_coupons_user_id")
   userId: string;
 
-  @Column({ type: "varchar", name: "order_id", length: 255, nullable: true })
+  @Column({ type: "uuid", name: "order_id", nullable: true })
   orderId: string | null;
 
   @Column({ type: "int", name: "discount_price", nullable: true })

--- a/src/order/infrastructure/persistence/orm/order-item.typeorm.entity.ts
+++ b/src/order/infrastructure/persistence/orm/order-item.typeorm.entity.ts
@@ -16,11 +16,11 @@ export class OrderItemTypeOrmEntity {
   @PrimaryGeneratedColumn("uuid")
   id: string;
 
-  @Column({ type: "varchar", length: 255, name: "order_id" })
+  @Column({ type: "uuid", name: "order_id" })
   @Index("idx_order_items_order_id")
   orderId: string;
 
-  @Column({ type: "varchar", length: 255, name: "product_id" })
+  @Column({ type: "uuid", name: "product_id" })
   @Index("idx_order_items_product_id")
   productId: string;
 

--- a/src/order/infrastructure/persistence/orm/order.typeorm.entity.ts
+++ b/src/order/infrastructure/persistence/orm/order.typeorm.entity.ts
@@ -26,7 +26,7 @@ export class OrderTypeOrmEntity {
   @PrimaryGeneratedColumn("uuid")
   id: string;
 
-  @Column({ type: "varchar", length: 255, name: "user_id" })
+  @Column({ type: "uuid", name: "user_id" })
   @Index("idx_orders_user_id")
   userId: string;
 
@@ -51,8 +51,7 @@ export class OrderTypeOrmEntity {
   idempotencyKey: string;
 
   @Column({
-    type: "varchar",
-    length: 255,
+    type: "uuid",
     name: "applied_user_coupon_id",
     nullable: true,
   })

--- a/src/order/infrastructure/persistence/orm/order.typeorm.entity.ts
+++ b/src/order/infrastructure/persistence/orm/order.typeorm.entity.ts
@@ -46,7 +46,7 @@ export class OrderTypeOrmEntity {
   @Column({ type: "text", name: "failed_reason", nullable: true })
   failedReason: string | null;
 
-  @Column({ type: "varchar", length: 255, name: "idempotency_key" })
+  @Column({ type: "varchar", length: 100, name: "idempotency_key" })
   @Index("idx_orders_idempotency_key", { unique: true })
   idempotencyKey: string;
 

--- a/src/product/infrastructure/persistence/orm/product.typeorm.entity.ts
+++ b/src/product/infrastructure/persistence/orm/product.typeorm.entity.ts
@@ -12,7 +12,7 @@ export class ProductTypeOrmEntity {
   @PrimaryGeneratedColumn("uuid")
   id: string;
 
-  @Column({ type: "varchar", length: 255, unique: true })
+  @Column({ type: "varchar", length: 100, unique: true })
   @Index("idx_products_name")
   name: string;
 

--- a/src/product/infrastructure/persistence/orm/stock-reservations.typeorm.entity.ts
+++ b/src/product/infrastructure/persistence/orm/stock-reservations.typeorm.entity.ts
@@ -16,10 +16,10 @@ export class StockReservationTypeOrmEntity {
   @PrimaryGeneratedColumn("uuid")
   id: string;
 
-  @Column({ type: "varchar", length: 255, name: "product_id" })
+  @Column({ type: "uuid", name: "product_id" })
   productId: string;
 
-  @Column({ type: "varchar", length: 255, name: "user_id" })
+  @Column({ type: "uuid", name: "user_id" })
   userId: string;
 
   @Column({ type: "integer" })
@@ -28,7 +28,7 @@ export class StockReservationTypeOrmEntity {
   @Column({ type: "boolean", name: "is_active", default: true })
   isActive: boolean;
 
-  @Column({ type: "varchar", length: 255, name: "order_id" })
+  @Column({ type: "uuid", name: "order_id" })
   orderId: string;
 
   @Column({ type: "timestamp", name: "expires_at" })

--- a/src/user/infrastructure/persistence/orm/user.typeorm.entity.ts
+++ b/src/user/infrastructure/persistence/orm/user.typeorm.entity.ts
@@ -12,7 +12,7 @@ export class UserTypeOrmEntity {
   @PrimaryGeneratedColumn("uuid")
   id: string;
 
-  @Column({ type: "varchar", length: 255, unique: true })
+  @Column({ type: "varchar", length: 50, unique: true })
   @Index("idx_users_email")
   email: string;
 

--- a/src/wallet/infrastructure/persistence/orm/point-transaction.typeorm.entity.ts
+++ b/src/wallet/infrastructure/persistence/orm/point-transaction.typeorm.entity.ts
@@ -21,7 +21,7 @@ export class PointTransactionTypeOrmEntity {
   @PrimaryGeneratedColumn("uuid")
   id: string;
 
-  @Column({ type: "varchar", name: "user_id" })
+  @Column({ type: "uuid", name: "user_id" })
   @Index("idx_point_transactions_user_id")
   userId: string;
 

--- a/src/wallet/infrastructure/persistence/orm/point-transaction.typeorm.entity.ts
+++ b/src/wallet/infrastructure/persistence/orm/point-transaction.typeorm.entity.ts
@@ -31,10 +31,15 @@ export class PointTransactionTypeOrmEntity {
   @Column({ type: "enum", name: "type", enum: PointTransactionType })
   type: PointTransactionType;
 
-  @Column({ type: "varchar", name: "idempotency_key", nullable: true })
+  @Column({
+    type: "varchar",
+    length: 100,
+    name: "idempotency_key",
+    nullable: true,
+  })
   idempotencyKey: string | null;
 
-  @Column({ type: "varchar", name: "ref_id", nullable: true })
+  @Column({ type: "varchar", length: 100, name: "ref_id", nullable: true })
   refId: string | null;
 
   @CreateDateColumn({ name: "created_at" })

--- a/src/wallet/infrastructure/persistence/orm/user-balance.typeorm.entity.ts
+++ b/src/wallet/infrastructure/persistence/orm/user-balance.typeorm.entity.ts
@@ -15,7 +15,7 @@ export class UserBalanceTypeOrmEntity {
   @PrimaryGeneratedColumn("uuid")
   id: string;
 
-  @Column({ type: "varchar", name: "user_id" })
+  @Column({ type: "uuid", name: "user_id" })
   @Index("idx_user_balances_user_id")
   userId: string;
 


### PR DESCRIPTION
### 💬 배경

- varchar 길이 너무 긴 것 축소
- fk 잘못 설정되어있던 타입들 varcher => uuidfh 로 수정

### 🤔 고민 포인트

- pk 모두 uuid아니라 그냥 number id로 수정하는 것이 장기적으로 속도, 관리 측면에서 더 좋아보임. 수정하다가보니 엔티티에서 create 할 때 id가 애매해져서 고민이 되어서 일단 시간 관계상 이후로 미룸